### PR TITLE
Remove the `etcdctl` binary when cleaning up

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -112,7 +112,8 @@
       path: "/usr/local/bin/{{ item }}"
       state: absent
     with_items:
-      - etcd   
+      - etcd
+      - etcdctl
 
 - hosts: masters
   tasks:


### PR DESCRIPTION
Just got started with Ansible today. I'm also not experienced with Kubernetes (outside of minikube) yet. Anyway, while studying your script(s), I noticed that the `etcdctl` binary wasn't cleaned up. Unless it shouldn't be, for some reason? :)