### PR TITLE
Set systemd service type to `notify` for `etcd`

### DIFF
--- a/roles/etcd/templates/etcd.service.j2
+++ b/roles/etcd/templates/etcd.service.j2
@@ -23,6 +23,7 @@ ExecStart=/usr/local/bin/etcd \
   --data-dir=/var/lib/etcd
 Restart=on-failure
 RestartSec=5
+Type=notify
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I was getting an error when starting etcd (it was running successfully, though, as far as I could see):

```
Dec 14 14:05:34 kubernetesmaster01 etcd[31989]: forgot to set Type=notify in systemd service file?
```

With this change, I can start up etcd without any errors in the logs.