### PR TITLE
Improve cleanup playbook

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -81,6 +81,7 @@
       - containerd-stress
       - runc
       - kubelet
+      - kube-proxy
 
 - hosts: etcd
   tasks:
@@ -153,7 +154,7 @@
 
   - name: Remove directories
     file:
-      path: "{( item }}"
+      path: "{{ item }}"
       state: absent
     with_items:
       - /etc/kubernetes
@@ -161,6 +162,15 @@
   - name: Remove binaries
     file:
       path: "/usr/local/bin/{{ item }}"
+      state: absent
+    with_items:
+      - kube-apiserver
+      - kube-controller-manager
+      - kube-scheduler
+
+  - name: Remove systemd unit files
+    file:
+      path: "/etc/systemd/system/{{ item }}.service"
       state: absent
     with_items:
       - kube-apiserver


### PR DESCRIPTION
The following is now cleaned up as expected:
* `/usr/local/bin/kube-proxy` (binary on workers)
* `/etc/systemd/system/kube-apiserver.service` (systemd unit file on masters)
* `/etc/systemd/system/kube-controller-manager.service` (systemd unit file on masters)
* `/etc/systemd/system/kube-scheduler.service` (systemd unit file on masters)
* `/etc/kubernetes` (config and SSL on masters)