### PR TITLE
Suggestion: Individual master hostnames in SSL certificate

### DIFF
--- a/roles/certificates/templates/openssl.conf.j2
+++ b/roles/certificates/templates/openssl.conf.j2
@@ -34,6 +34,9 @@ DNS.2 = kubernetes.default
 DNS.3 = kubernetes.default.svc
 DNS.4 = kubernetes.default.svc.cluster.local
 DNS.5 = {{ cluster_hostname }}
+{% for host in groups['masters'] %}
+DNS.{{ loop.index + 5 }} = {{ host }}
+{% endfor %}
 IP.1 = 127.0.0.1
 IP.2 = 10.32.0.1
 {% for host in groups['masters'] %}


### PR DESCRIPTION
This might not be the way to go, this is just a suggestion up for discussion. The point is that I'd like to be able to access the cluster using a specific hostname of one of the masters.

Background:

I'd like to specify a specific hostname for my clusters, for example `k8s.service.office.local` (where `office.local` is the domain). This hostname is load balanced against all masters, right? However, I haven't decided how I want to load balance it yet. I was thinking of using the nginx **within** the cluster (if possible, I haven't checked that out yet) to load balance the masters themselves. To be able to set up my NGINX Ingress Controller in my new cluster, I must be able to access it with `kubectl`, which I can't do yet, since the load balanced domain isn't actually working yet. Therefore, I temporarily need to use the direct hostnames of one of the masters.

Also, out of curiousity, what's the reason for these DNS-rows:
```
DNS.1 = kubernetes
DNS.2 = kubernetes.default
DNS.3 = kubernetes.default.svc
DNS.4 = kubernetes.default.svc.cluster.local
```