### PR TITLE
Suggestion: Make sure we're not becoming another user in `localhost`

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -3,6 +3,7 @@
   roles:
     - kubectl
     - certificates
+  become: no
 
 - hosts: etcd
   roles:


### PR DESCRIPTION
I had some struggle with permissions when running Ansible. When testing this repository at first, I added the following to my `inventory` file:
```
[all:vars]
ansible_connection=ssh
ansible_user=root
ansible_ssh_pass=some-password
```

That worked, of course, but it didn't feel right. I googled around a bit, and came up with the following:
```
$ ansible-playbook --become --become-method sudo --ask-become-pass --inventory inventory install.yml
```

This elevates the permissions of **all** hosts/roles. However, I wouldn't want the permissions to be elevated to `sudo` for `localhost`.

How do you usually handle these sorts of things?