### PR TITLE
Suggestion: Allow overriding the cluster name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are a few variabels that you may set to furher customize the deployment.
 | `config_path` 	| `False` 	| `~/.ktrw` 	| A path to a directory on the control host were cluster certificates and configuration is created. 	|
 | `cluster_hostname` 	| `False` 	| `groups['masters'][0]` 	| The public hostname of the cluster. Defaults to the hostname of the first master in the [inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html). For multi-master installations, the value of cluster_hostname is usually a load balancer. 	|
 | `cluster_port` 	| `False` 	| `6443` 	| The port number on which kube-apiserver listens on. 	|
+| `cluster_name` 	| `False` 	| `cluster_hostname.split('.')[0]` 	| The name of the cluster, used for identification in `kubectl`. Defaults to the first segment of the `cluster_hostname`. 	|
 | `regenerate_certificates` 	| `False` 	| `False` 	| Set to True to force create certificates. This will overwrite existing certificates. 	|
 | `regenerate_keys` 	| `False` 	| `False` 	| Set to True to force create private certificates (keys). This will overwrite existing certificates. 	|
 

--- a/roles/certificates/tasks/main.yml
+++ b/roles/certificates/tasks/main.yml
@@ -13,7 +13,7 @@
     regenerate_keys: "{{ regenerate_keys | default(False) }}"
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -7,7 +7,7 @@
   delegate_to: 127.0.0.1
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -8,7 +8,7 @@
   delegate_to: 127.0.0.1
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -7,7 +7,7 @@
   delegate_to: 127.0.0.1
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -8,7 +8,7 @@
   delegate_to: 127.0.0.1
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -7,7 +7,7 @@
   delegate_to: 127.0.0.1
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -8,7 +8,7 @@
   delegate_to: 127.0.0.1
 
 - set_fact:
-    cluster_name: "{{ cluster_hostname.split('.')[0] | default('kubernetes') }}"
+    cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"


### PR DESCRIPTION
This is useful if you have multiple clusters whose hostnames all start with the same part, for example:
```
k8s.service.office.local
k8s.service.production.local
```

With this fix, I could call my clusters `stage` and `production` (where the `stage` cluster would be running on the office domain, while the `production` cluster would be running in the production domain).