### PR TITLE
Properly unmount directories in `/var/lib/kubelet`

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -57,13 +57,17 @@
     file:
       path: /etc/systemd/system/kube-proxy.service
       state: absent
-  
+
+  - name: Find mounted directories
+    shell: "awk '$2 ~ path {print $2}' path=/var/lib/kubelet /proc/mounts"
+    register: "result"
+
   - name: Unmount volumes
     mount:
       path: "{{ item }}"
       state: unmounted
     with_items:
-      - /var/lib/kubelet
+      - "{{ result.stdout_lines }}"
 
   - name: Remove directories
     file:


### PR DESCRIPTION
Closes #12

I decided to "replace" the existing task for unmounting `/var/lib/kubelet` because I think this new one does the trick for everything. But if it's not, let me know and I'll put it back.