### PR TITLE
Remove `containerd-shim-runc-v1` as well when cleaning up

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -88,6 +88,7 @@
       - ctr
       - containerd
       - containerd-shim
+      - containerd-shim-runc-v1
       - containerd-release
       - containerd-stress
       - runc


### PR DESCRIPTION
Looks like this binary is new in containerd 1.2, see contents of `https://github.com/containerd/containerd/releases/download/v1.2.1/containerd-1.2.1.linux-amd64.tar.gz`.