### PR TITLE
Use the correct hostname in kubelet's kubeconfig

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -10,12 +10,14 @@
 
 - hosts: masters
   roles:
+    - kubectl
     - kube-apiserver
     - kube-controller-manager
     - kube-scheduler
 
 - hosts: nodes
   roles:
+    - kubectl
     - cni
     - containerd
     - runc

--- a/install.yml
+++ b/install.yml
@@ -10,14 +10,12 @@
 
 - hosts: masters
   roles:
-    - kubectl
     - kube-apiserver
     - kube-controller-manager
     - kube-scheduler
 
 - hosts: nodes
   roles:
-    - kubectl
     - cni
     - containerd
     - runc

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - set_fact:
     cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
+    cluster_port: "{{ cluster_port | default('6443') }}"
 
 - set_fact:
     config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
@@ -40,17 +41,14 @@
     - "{{ cluster_config_path }}/pki/master/kube-controller-manager-key.pem"
     - "{{ cluster_config_path }}/pki/master/service-account-key.pem"
 
-- name: Create controller-manager kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://127.0.0.1:6443 --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
-
-- name: set-credentials 
-  command: "kubectl config set-credentials system:kube-controller-manager --client-certificate /etc/kubernetes/pki/kube-controller-manager.pem --client-key /etc/kubernetes/pki/kube-controller-manager-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
-
-- name: set-context 
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-controller-manager --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
-
-- name: use-context 
-  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
+- name: Create kubeconfig
+  template:
+    src: kube-controller-manager.kubeconfig
+    dest: "/etc/kubernetes/config/kube-controller-manager.kubeconfig"
+  vars:
+    certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
+    client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-controller-manager.pem') | b64encode }}"
+    client_key_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-controller-manager-key.pem') | b64encode }}"
 
 - name: Create systemd unit file
   template:

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -41,35 +41,16 @@
     - "{{ cluster_config_path }}/pki/master/service-account-key.pem"
 
 - name: Create controller-manager kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority {{ cluster_config_path }}/pki/master/ca.pem --embed-certs=true --server=https://127.0.0.1:6443 --kubeconfig {{ cluster_config_path }}/kube-controller-manager.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://127.0.0.1:6443 --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
 
 - name: set-credentials 
-  command: "kubectl config set-credentials system:kube-controller-manager --client-certificate {{ cluster_config_path }}/pki/master/kube-controller-manager.pem --client-key {{ cluster_config_path }}/pki/master/kube-controller-manager-key.pem --embed-certs=true --kubeconfig {{ cluster_config_path }}/kube-controller-manager.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-credentials system:kube-controller-manager --client-certificate /etc/kubernetes/pki/kube-controller-manager.pem --client-key /etc/kubernetes/pki/kube-controller-manager-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
 
 - name: set-context 
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-controller-manager --kubeconfig {{ cluster_config_path }}/kube-controller-manager.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-controller-manager --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
 
 - name: use-context 
-  command: "kubectl config use-context default --kubeconfig {{ cluster_config_path }}/kube-controller-manager.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-
-- name: Change file permission for kubeconfig
-  file:
-    path: "{{ cluster_config_path }}/kube-controller-manager.kubeconfig"
-    mode: 0644
-  delegate_to: 127.0.0.1
-
-- name: Copy kubeconfig
-  copy:
-    src: "{{ cluster_config_path }}/kube-controller-manager.kubeconfig"
-    dest: /etc/kubernetes/config/kube-controller-manager.kubeconfig
+  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/kube-controller-manager.kubeconfig"
 
 - name: Create systemd unit file
   template:

--- a/roles/kube-controller-manager/templates/kube-controller-manager.kubeconfig
+++ b/roles/kube-controller-manager/templates/kube-controller-manager.kubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: {{ certificate_authority_data }}
+    server: https://{{ cluster_hostname }}:{{ cluster_port }}
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: system:kube-controller-manager
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: system:kube-controller-manager
+  user:
+    client-certificate-data: {{ client_certificate_data }}
+    client-key-data: {{ client_key_data }}

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -39,17 +39,14 @@
     - "{{ cluster_config_path }}/pki/master/kube-proxy.pem"
     - "{{ cluster_config_path }}/pki/master/kube-proxy-key.pem"
 
-- name: Create kube-proxy kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
-
-- name: set-credentials 
-  command: "kubectl config set-credentials system:kube-proxy --client-certificate /etc/kubernetes/pki/kube-proxy.pem --client-key /etc/kubernetes/pki/kube-proxy-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
- 
-- name: set-context
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-proxy --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
- 
-- name: use-context
-  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
+- name: Create kubeconfig
+  template:
+    src: kube-proxy.kubeconfig
+    dest: "/etc/kubernetes/config/kube-proxy.kubeconfig"
+  vars:
+    certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
+    client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-proxy.pem') | b64encode }}"
+    client_key_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-proxy-key.pem') | b64encode }}"
 
 - name: Copy kube-proxy config
   copy:

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -30,36 +30,26 @@
     - pki
     - config
 
+- name: Copy certificates
+  copy:
+    src: "{{ item }}"
+    dest: /etc/kubernetes/pki
+  with_items:
+    - "{{ cluster_config_path }}/pki/master/ca.pem"
+    - "{{ cluster_config_path }}/pki/master/kube-proxy.pem"
+    - "{{ cluster_config_path }}/pki/master/kube-proxy-key.pem"
+
 - name: Create kube-proxy kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority {{ cluster_config_path }}/pki/master/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig {{ cluster_config_path }}/kube-proxy.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
 
 - name: set-credentials 
-  command: "kubectl config set-credentials system:kube-proxy --client-certificate {{ cluster_config_path }}/pki/master/kube-proxy.pem --client-key {{ cluster_config_path }}/pki/master/kube-proxy-key.pem --embed-certs=true --kubeconfig {{ cluster_config_path }}/kube-proxy.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-credentials system:kube-proxy --client-certificate /etc/kubernetes/pki/kube-proxy.pem --client-key /etc/kubernetes/pki/kube-proxy-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
  
 - name: set-context
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-proxy --kubeconfig {{ cluster_config_path }}/kube-proxy.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-proxy --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
  
 - name: use-context
-  command: "kubectl config use-context default --kubeconfig {{ cluster_config_path }}/kube-proxy.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-
-- name: Change file permission for kubeconfig
-  file:
-    path: "{{ cluster_config_path }}/kube-proxy.kubeconfig"
-    mode: 0644
-  delegate_to: 127.0.0.1
-
-- name: Copy kubeconfig
-  copy:
-    src: "{{ cluster_config_path }}/kube-proxy.kubeconfig"
-    dest: /etc/kubernetes/config/kube-proxy.kubeconfig
+  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/kube-proxy.kubeconfig"
 
 - name: Copy kube-proxy config
   copy:

--- a/roles/kube-proxy/templates/kube-proxy.kubeconfig
+++ b/roles/kube-proxy/templates/kube-proxy.kubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: {{ certificate_authority_data }}
+    server: https://{{ cluster_hostname }}:{{ cluster_port }}
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: system:kube-proxy
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: system:kube-proxy
+  user:
+    client-certificate-data: {{ client_certificate_data }}
+    client-key-data: {{ client_key_data }}

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -44,35 +44,16 @@
     dest: /etc/kubernetes/config/
 
 - name: Create kube-scheduler kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority {{ cluster_config_path }}/pki/master/ca.pem --embed-certs=true --server=https://127.0.0.1:6443 --kubeconfig {{ cluster_config_path }}/kube-scheduler.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://127.0.0.1:6443 --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
 
 - name: set-credentials 
-  command: "kubectl config set-credentials system:kube-scheduler --client-certificate {{ cluster_config_path }}/pki/master/kube-scheduler.pem --client-key {{ cluster_config_path }}/pki/master/kube-scheduler-key.pem --embed-certs=true --kubeconfig {{ cluster_config_path }}/kube-scheduler.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-credentials system:kube-scheduler --client-certificate /etc/kubernetes/pki/kube-scheduler.pem --client-key /etc/kubernetes/pki/kube-scheduler-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
 
 - name: set-context 
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-scheduler --kubeconfig {{ cluster_config_path }}/kube-scheduler.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
+  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-scheduler --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
 
 - name: use-context 
-  command: "kubectl config use-context default --kubeconfig {{ cluster_config_path }}/kube-scheduler.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-
-- name: Change file permission for kubeconfig
-  file:
-    path: "{{ cluster_config_path }}/kube-scheduler.kubeconfig"
-    mode: 0644
-  delegate_to: 127.0.0.1
-
-- name: Copy kubeconfig
-  copy:
-    src: "{{ cluster_config_path }}/kube-scheduler.kubeconfig"
-    dest: /etc/kubernetes/config/kube-scheduler.kubeconfig
+  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
 
 - name: Create systemd unit file
   template:

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - set_fact:
     cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
+    cluster_port: "{{ cluster_port | default('6443') }}"
 
 - set_fact:
     config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
@@ -38,22 +39,19 @@
     - "{{ cluster_config_path }}/pki/master/kube-scheduler.pem"
     - "{{ cluster_config_path }}/pki/master/kube-scheduler-key.pem"
 
+- name: Create kubeconfig
+  template:
+    src: kube-scheduler.kubeconfig
+    dest: "/etc/kubernetes/config/kube-scheduler.kubeconfig"
+  vars:
+    certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
+    client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-scheduler.pem') | b64encode }}"
+    client_key_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-scheduler-key.pem') | b64encode }}"
+
 - name: Copy scheduler config
   copy:
     src: kube-scheduler.yml
     dest: /etc/kubernetes/config/
-
-- name: Create kube-scheduler kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://127.0.0.1:6443 --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
-
-- name: set-credentials 
-  command: "kubectl config set-credentials system:kube-scheduler --client-certificate /etc/kubernetes/pki/kube-scheduler.pem --client-key /etc/kubernetes/pki/kube-scheduler-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
-
-- name: set-context 
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:kube-scheduler --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
-
-- name: use-context 
-  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/kube-scheduler.kubeconfig"
 
 - name: Create systemd unit file
   template:

--- a/roles/kube-scheduler/templates/kube-scheduler.kubeconfig
+++ b/roles/kube-scheduler/templates/kube-scheduler.kubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: {{ certificate_authority_data }}
+    server: https://{{ cluster_hostname }}:{{ cluster_port }}
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: system:kube-scheduler
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: system:kube-scheduler
+  user:
+    client-certificate-data: {{ client_certificate_data }}
+    client-key-data: {{ client_key_data }}

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -39,16 +39,16 @@
     - "{{ cluster_config_path }}/pki/master/ca.pem"
 
 - name: Create kubelet kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
+  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
 
 - name: set-credentials 
-  command: "kubectl config set-credentials system:node:{{ hostvars[item].inventory_hostname }} --client-certificate /etc/kubernetes/pki/system:node:{{ hostvars[item].inventory_hostname }}.pem --client-key /etc/kubernetes/pki/system:node:{{ hostvars[item].inventory_hostname }}-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
+  command: "kubectl config set-credentials system:node:{{ inventory_hostname }} --client-certificate /etc/kubernetes/pki/system:node:{{ inventory_hostname }}.pem --client-key /etc/kubernetes/pki/system:node:{{ inventory_hostname }}-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
  
 - name: set-context
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:node:{{ hostvars[item].inventory_hostname }} --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
+  command: "kubectl config set-context default --cluster=kubernetes --user=system:node:{{ inventory_hostname }} --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
  
 - name: use-context
-  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
+  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
 
 - name: Create kubelet config
   template:

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -45,7 +45,7 @@
   with_items: "{{ groups['nodes'] }}"
 
 - name: set-credentials 
-  command: "kubectl config set-credentials system:node:{{ inventory_hostname }} --client-certificate {{ cluster_config_path }}/pki/node/system:node:{{ inventory_hostname }}.pem --client-key {{ cluster_config_path }}/pki/node/system:node:{{ hostvars[item].inventory_hostname }}-key.pem --embed-certs=true --kubeconfig {{ cluster_config_path }}/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
+  command: "kubectl config set-credentials system:node:{{ hostvars[item].inventory_hostname }} --client-certificate {{ cluster_config_path }}/pki/node/system:node:{{ hostvars[item].inventory_hostname }}.pem --client-key {{ cluster_config_path }}/pki/node/system:node:{{ hostvars[item].inventory_hostname }}-key.pem --embed-certs=true --kubeconfig {{ cluster_config_path }}/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
   delegate_to: 127.0.0.1
   run_once: True
   with_items: "{{ groups['nodes'] }}"

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -39,39 +39,16 @@
     - "{{ cluster_config_path }}/pki/master/ca.pem"
 
 - name: Create kubelet kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority {{ cluster_config_path }}/pki/master/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig {{ cluster_config_path }}/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-  with_items: "{{ groups['nodes'] }}"
+  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
 
 - name: set-credentials 
-  command: "kubectl config set-credentials system:node:{{ hostvars[item].inventory_hostname }} --client-certificate {{ cluster_config_path }}/pki/node/system:node:{{ hostvars[item].inventory_hostname }}.pem --client-key {{ cluster_config_path }}/pki/node/system:node:{{ hostvars[item].inventory_hostname }}-key.pem --embed-certs=true --kubeconfig {{ cluster_config_path }}/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-  with_items: "{{ groups['nodes'] }}"
+  command: "kubectl config set-credentials system:node:{{ hostvars[item].inventory_hostname }} --client-certificate /etc/kubernetes/pki/system:node:{{ hostvars[item].inventory_hostname }}.pem --client-key /etc/kubernetes/pki/system:node:{{ hostvars[item].inventory_hostname }}-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
  
 - name: set-context
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:node:{{ hostvars[item].inventory_hostname }} --kubeconfig {{ cluster_config_path }}/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-  with_items: "{{ groups['nodes'] }}"
+  command: "kubectl config set-context default --cluster=kubernetes --user=system:node:{{ hostvars[item].inventory_hostname }} --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
  
 - name: use-context
-  command: "kubectl config use-context default --kubeconfig {{ cluster_config_path }}/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
-  delegate_to: 127.0.0.1
-  run_once: True
-  with_items: "{{ groups['nodes'] }}"
-
-- name: Change file permission for kubeconfig
-  file:
-    path: "{{ cluster_config_path }}/system:node:{{ inventory_hostname }}.kubeconfig"
-    mode: 0644
-  delegate_to: 127.0.0.1
-
-- name: Copy kubeconfig
-  copy:
-    src: "{{ cluster_config_path }}/system:node:{{ inventory_hostname }}.kubeconfig"
-    dest: /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig
+  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/system:node:{{ hostvars[item].inventory_hostname }}.kubeconfig"
 
 - name: Create kubelet config
   template:

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -38,17 +38,14 @@
     - "{{ cluster_config_path }}/pki/node/system:node:{{ inventory_hostname }}*"
     - "{{ cluster_config_path }}/pki/master/ca.pem"
 
-- name: Create kubelet kubeconfig
-  command: "kubectl config set-cluster kubernetes --certificate-authority /etc/kubernetes/pki/ca.pem --embed-certs=true --server=https://{{ cluster_hostname }}:{{ cluster_port }} --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
-
-- name: set-credentials 
-  command: "kubectl config set-credentials system:node:{{ inventory_hostname }} --client-certificate /etc/kubernetes/pki/system:node:{{ inventory_hostname }}.pem --client-key /etc/kubernetes/pki/system:node:{{ inventory_hostname }}-key.pem --embed-certs=true --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
- 
-- name: set-context
-  command: "kubectl config set-context default --cluster=kubernetes --user=system:node:{{ inventory_hostname }} --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
- 
-- name: use-context
-  command: "kubectl config use-context default --kubeconfig /etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
+- name: Create kubeconfig
+  template:
+    src: node.kubeconfig
+    dest: "/etc/kubernetes/config/system:node:{{ inventory_hostname }}.kubeconfig"
+  vars:
+    certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
+    client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/node/system:node:'+inventory_hostname+'.pem') | b64encode }}"
+    client_key_data: "{{ lookup('file', cluster_config_path+'/pki/node/system:node:'+inventory_hostname+'-key.pem') | b64encode }}"
 
 - name: Create kubelet config
   template:

--- a/roles/kubelet/templates/node.kubeconfig
+++ b/roles/kubelet/templates/node.kubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: {{ certificate_authority_data }}
+    server: https://{{ cluster_hostname }}:{{ cluster_port }}
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: system:node:{{ inventory_hostname }}
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: system:node:{{ inventory_hostname }}
+  user:
+    client-certificate-data: {{ client_certificate_data }}
+    client-key-data: {{ client_key_data }}


### PR DESCRIPTION
Closes #22 

There was a mix of `hostvars[item].inventory_hostname` and `inventory_hostname` in a task that had `run_once: True`, causing it to give all nodes the hostname of the first node in the credentials part of kubeconfig.

Here's an example kubeconfig of my `k8s-worker-02` before this fix:
```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <redacted>
    server: https://k8s-master-01:6443
  name: kubernetes
contexts:
- context:
    cluster: kubernetes
    user: system:node:k8s-worker-02
  name: default
current-context: default
kind: Config
preferences: {}
users:
- name: system:node:k8s-worker-01
  user:
    client-certificate-data: <redacted>
    client-key-data: <redacted>
```