### PR TITLE
Added checksum prop to `get_url` module wherever possible

### DIFF
--- a/roles/cni/tasks/main.yml
+++ b/roles/cni/tasks/main.yml
@@ -5,14 +5,46 @@
     path: "{{ item }}"
     mode: 0755
   with_items:
+    - /tmp/cni
     - /etc/cni/net.d
     - /opt/cni/bin
 
 - name: Download cni
+  get_url:
+    url: https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
+    dest: /tmp/cni-plugins-amd64-v0.6.0.tgz
+    mode: 0755
+    owner: root
+    group: root
+    checksum: sha256:f04339a21b8edf76d415e7f17b620e63b8f37a76b2f706671587ab6464411f2d
+
+- name: Unarchive tarball
   unarchive:
-    src: https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
-    dest: /opt/cni/bin/
+    src: /tmp/cni-plugins-amd64-v0.6.0.tgz
+    dest: /tmp/cni
     remote_src: True
+
+- name: List binaries
+  find:
+    paths: /tmp/cni
+    file_type: file
+  register: result
+
+- name: Move binaries into place
+  copy:
+    src: "{{ item.path }}"
+    dest: "/opt/cni/bin/{{ item.path | basename }}"
+    mode: 0755
+    remote_src: True
+  with_items: "{{ result.files }}"
+
+- name: Remove tmp download files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /tmp/cni-plugins-amd64-v0.6.0.tgz
+    - /tmp/cni
 
 - name: Create networks
   template:

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -5,13 +5,45 @@
     path: "{{ item }}"
     mode: 0755
   with_items:
+    - /tmp/containerd
     - /etc/containerd
 
 - name: Download containerd
+  get_url:
+    url: https://github.com/containerd/containerd/releases/download/v1.2.1/containerd-1.2.1.linux-amd64.tar.gz
+    dest: /tmp/containerd-1.2.1.linux-amd64.tar.gz
+    mode: 0755
+    owner: root
+    group: root
+    checksum: sha256:9818e3af4f9aac8d55fc3f66114346db1d1acd48d45f88b2cefd3d3bafb380e0
+
+- name: Unarchive tarball
   unarchive:
-    src: https://github.com/containerd/containerd/releases/download/v1.2.1/containerd-1.2.1.linux-amd64.tar.gz
-    dest: /usr/local/
+    src: /tmp/containerd-1.2.1.linux-amd64.tar.gz
+    dest: /tmp/containerd
     remote_src: True
+
+- name: List binaries
+  find:
+    paths: /tmp/containerd/bin
+    file_type: file
+  register: result
+
+- name: Move binaries into place
+  copy:
+    src: "{{ item.path }}"
+    dest: "/usr/local/bin/{{ item.path | basename }}"
+    mode: 0755
+    remote_src: True
+  with_items: "{{ result.files }}"
+
+- name: Remove tmp download files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /tmp/containerd-1.2.1.linux-amd64.tar.gz
+    - /tmp/containerd
 
 - name: Create configuration
   template:

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -19,6 +19,7 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1
 
 - name: Unarchive etcd tarball
   unarchive:

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -20,6 +20,7 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:0e5adc6d7dc00d923ef23ff6027d5d4668ade914aad0fbd2420e48c9cb24421c
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -19,6 +19,7 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:1f9406b8fbb661f43e9b7d270467161e37f2882369030618aea8e59f0d147565
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -20,6 +20,7 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:8301177da56b6306b70a70da666334209a1ce8f35a928309c2b025f80ad1335b
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -19,6 +19,7 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:a7e906b02d4632a9bbf0cc1a457b2e08445856765f764e7e06336ec7c35462c2
 
 - name: Ensure directories exist
   file:

--- a/roles/kubectl/tasks/main.yml
+++ b/roles/kubectl/tasks/main.yml
@@ -5,6 +5,7 @@
     url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubectl
     dest: /usr/local/bin/kubectl
     mode: 0755
+    checksum: sha256:8668ecbf286774e5f7d9aa849f95af2940c491a258459f93c5dd3e3c836c2cb1
   when: ansible_distribution != 'MacOSX'
 
 # Kubectl for MacOS
@@ -13,4 +14,5 @@
     url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/darwin/amd64/kubectl
     dest: /usr/local/bin/kubectl
     mode: 0755
+    checksum: sha256:ddebf621822a477ade23aeb3a00f214591e5031342f3a52403c0be8fa1696d2b
   when: ansible_distribution == 'MacOSX'

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -20,6 +20,7 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:5d6c5872d314e6c551d8ec1617f94367756f93121ab6102d363f87e64d4998f6
 
 - name: Ensure directories exist
   file:

--- a/roles/runc/tasks/main.yml
+++ b/roles/runc/tasks/main.yml
@@ -6,3 +6,4 @@
     mode: 0755
     owner: root
     group: root
+    checksum: sha256:860dbff86558313caf23030f9638d1bcd7a43533f12227628f4abd678eef35c1


### PR DESCRIPTION
Added `checksum` prop to [get_url](https://docs.ansible.com/ansible/latest/modules/get_url_module.html) module in order to determine if binaries should be downloaded or skipped if already exists. Without this, upgrading a cluster, let's say from from `1.11.2` to `1.13.1` would not download new binaries since the already exists in the hosts.