### PR TITLE
Use default flags to kube-scheduler

### DIFF
--- a/roles/kube-scheduler/templates/kube-scheduler.service.j2
+++ b/roles/kube-scheduler/templates/kube-scheduler.service.j2
@@ -4,8 +4,7 @@ Documentation=https://github.com/kubernetes/kubernetes
 
 [Service]
 ExecStart=/usr/local/bin/kube-scheduler \
-  --config=/etc/kubernetes/config/kube-scheduler.yml \
-  --v=2
+  --config=/etc/kubernetes/config/kube-scheduler.yml
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
Removed flags from kube-scheduler which uses the defaults anyway