### PR TITLE
Allow dynamic configuration of `kube-apiserver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ There are a few variables that you may set to further customize the deployment.
 | `cluster_port` 	| `False` 	| `6443` 	| The port number on which kube-apiserver listens on. 	|
 | `cluster_name` 	| `False` 	| `cluster_hostname.split('.')[0]` 	| The name of the cluster, used for identification in `kubectl`. Defaults to the first segment of the `cluster_hostname`. 	|
 | `cluster_cidr` 	| `False` 	| `10.19.0.0/16` 	| CIDR Range for Pods in cluster. This effectively sets the `--cluster-cidr` flag on `kube-controller-manager`.	|
-| `enable_admission_plugins` 	| `False` 	| 	| Sets the `--enable-admission-plugins` kube-apiserver argument. 	|
 | `regenerate_certificates` 	| `False` 	| `False` 	| Set to True to force create certificates. This will overwrite existing certificates. 	|
 | `regenerate_keys` 	| `False` 	| `False` 	| Set to True to force create private certificates (keys). This will overwrite existing certificates. 	|
+| `flags_apiserver` 	| `False` 	| 	| Additional options to kube-apiserver as an array, for example: ['enable-admission-plugins=PodSecurityPolicy'] 	|
 
 # Deploying a cluster
 Configure an Ansible [inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html) file with the host groups `etcd`, `masters` and `nodes` and assign any host to their respective groups. Have a look at the [examples](https://github.com/amimof/kubernetes-the-right-way/tree/master/example). 

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -2,6 +2,7 @@
 - set_fact:
     cluster_port: "{{ cluster_port | default('6443') }}"
     cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
+    flags_apiserver: "{{ flags_apiserver | default([]) }}"
 
 - set_fact:
     config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"

--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -4,6 +4,9 @@ Documentation=https://github.com/kubernetes/kubernetes
 
 [Service]
 ExecStart=/usr/local/bin/kube-apiserver \
+{% for flag in flags_apiserver %}
+  --{{ flag }} \
+{% endfor %}
   --advertise-address={{ ansible_default_ipv4.address }} \
   --allow-privileged=true \
   --audit-log-maxage=30 \
@@ -15,9 +18,6 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --secure-port={{ cluster_port }} \
   --insecure-port=0 \
   --client-ca-file=/etc/kubernetes/pki/ca.pem \
-{% if enable_admission_plugins is defined %}
-  --enable-admission-plugins={{ enable_admission_plugins }} \
-{% endif %}
   --etcd-cafile=/etc/etcd/pki/ca.pem \
   --etcd-certfile=/etc/etcd/pki/etcd.pem \
   --etcd-keyfile=/etc/etcd/pki/etcd-key.pem \

--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -29,6 +29,7 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --tls-cert-file=/etc/kubernetes/pki/apiserver.pem \
   --tls-private-key-file=/etc/kubernetes/pki/apiserver-key.pem{% for flag in flags_apiserver %} \
   --{{ flag }}{% endfor %}
+
 Restart=on-failure
 RestartSec=5
 

--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -4,9 +4,6 @@ Documentation=https://github.com/kubernetes/kubernetes
 
 [Service]
 ExecStart=/usr/local/bin/kube-apiserver \
-{% for flag in flags_apiserver %}
-  --{{ flag }} \
-{% endfor %}
   --advertise-address={{ ansible_default_ipv4.address }} \
   --allow-privileged=true \
   --audit-log-maxage=30 \
@@ -30,7 +27,8 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --service-account-key-file=/etc/kubernetes/pki/service-account-key.pem \
   --service-cluster-ip-range=10.32.0.0/24 \
   --tls-cert-file=/etc/kubernetes/pki/apiserver.pem \
-  --tls-private-key-file=/etc/kubernetes/pki/apiserver-key.pem
+  --tls-private-key-file=/etc/kubernetes/pki/apiserver-key.pem{% for flag in flags_apiserver %} \
+  --{{ flag }}{% endfor %}
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
This replaces `enable_admission_plugins`. I don't think this complicates things more than `enable_admission_plugins` used to do, and I can very easily add whatever options I want, like this:

```
[all:vars]
custom_options_apiserver=--enable-admission-plugins=PodSecurityPolicy --oidc-issuer-url=https://dex.svc.example.local --oidc-client-id=loginapp --oidc-ca-file=/etc/kubernetes/pki/custom-ca.crt --oidc-username-claim=email --oidc-groups-claim=groups
```

Closes #37