### PR TITLE
Remove kube_apiserver double dash from template

### DIFF
--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -28,8 +28,8 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --service-cluster-ip-range=10.32.0.0/24 \
   --tls-cert-file=/etc/kubernetes/pki/apiserver.pem \
   --tls-private-key-file=/etc/kubernetes/pki/apiserver-key.pem{% for flag in flags_apiserver %} \
-  --{{ flag }}{% endfor %}
-
+  {{ flag }}{% endfor %}
+  
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
Removed `--` from service unit file template for `kube-apiserver`. I think it makes more sense to the user and also allows for shorthand flags.