### PR TITLE
Update component versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.13.1
-Server Version: v1.13.1
+Client Version: v1.14.0
+Server Version: v1.14.0
 ```
 
 ## Installing additional plugins
@@ -99,15 +99,15 @@ To add a node to an existing cluster is as easy as adding it to the [inventory](
 
 | Name                      | Version   | Role       |
 | ------------------------- | --------- | ---------- |
-| cni                       | 0.6.0     | node       |
-| containerd                | 1.2.1     | node       |
-| etcd                      | 3.3.9     | etcd       |
-| kube-apiserver            | 1.13.1    | master     |
-| kube-controller-manager   | 1.13.1    | master     |
-| kube-scheduler            | 1.13.1    | master     |
-| kube-proxy                | 1.13.1    | node       |
-| kubelet                   | 1.13.1    | node       |
-| kubectl                   | 1.13.1    | controller |
+| cni                       | 0.7.5     | node       |
+| containerd                | 1.2.5     | node       |
+| etcd                      | 3.3.12     | etcd       |
+| kube-apiserver            | 1.14.0    | master     |
+| kube-controller-manager   | 1.14.0    | master     |
+| kube-scheduler            | 1.14.0    | master     |
+| kube-proxy                | 1.14.0    | node       |
+| kubelet                   | 1.14.0    | node       |
+| kubectl                   | 1.14.0    | controller |
 | runc                      | 1.0.0-rc6 | node       |
 
 # How to contribute

--- a/roles/cni/tasks/main.yml
+++ b/roles/cni/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download cni
   unarchive:
-    src: https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz
+    src: https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz
     dest: /opt/cni/bin/
     remote_src: True
 

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Download containerd
   unarchive:
-    src: https://github.com/containerd/containerd/releases/download/v1.2.1/containerd-1.2.1.linux-amd64.tar.gz
+    src: https://github.com/containerd/containerd/releases/download/v1.2.5/containerd-1.2.5.linux-amd64.tar.gz
     dest: /usr/local/
     remote_src: True
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -14,22 +14,22 @@
 
 - name: Download etcd
   get_url:
-    url: https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz
-    dest: /tmp/etcd-v3.3.9-linux-amd64.tar.gz
+    url: https://github.com/coreos/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz
+    dest: /tmp/etcd-v3.3.12-linux-amd64.tar.gz
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1
+    checksum: sha256:dc5d82df095dae0a2970e4d870b6929590689dd707ae3d33e7b86da0f7f211b6
 
 - name: Unarchive etcd tarball
   unarchive:
-    src: /tmp/etcd-v3.3.9-linux-amd64.tar.gz
+    src: /tmp/etcd-v3.3.12-linux-amd64.tar.gz
     dest: /tmp
     remote_src: True
 
 - name: Move etcd binaries into place
   copy:
-    src: "/tmp/etcd-v3.3.9-linux-amd64/{{ item }}"
+    src: "/tmp/etcd-v3.3.12-linux-amd64/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     remote_src: True
   with_items:
@@ -41,8 +41,8 @@
     path: "/tmp/{{ item }}"
     state: absent
   with_items:
-    - etcd-v3.3.9-linux-amd64
-    - etcd-v3.3.9-linux-amd64.tar.gz
+    - etcd-v3.3.12-linux-amd64
+    - etcd-v3.3.12-linux-amd64.tar.gz
 
 - name: Make etcd binaries executable
   file:

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:0e5adc6d7dc00d923ef23ff6027d5d4668ade914aad0fbd2420e48c9cb24421c
+    checksum: sha256:6a27afb355a9dda9dddcdbe3c2d031a5c843036cdc2f453841992c111978e008
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:1f9406b8fbb661f43e9b7d270467161e37f2882369030618aea8e59f0d147565
+    checksum: sha256:00386973f990bfd90fbd944a02111d0b92179ed7612414e1aa7f836dd177659e
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:8301177da56b6306b70a70da666334209a1ce8f35a928309c2b025f80ad1335b
+    checksum: sha256:21fa27ad16f56b28fa6d57a8be84174fd93daf6ccf90a1f40e3924df0fe69468
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:a7e906b02d4632a9bbf0cc1a457b2e08445856765f764e7e06336ec7c35462c2
+    checksum: sha256:860f3bfbf81c7e5834fc6db1806a54c0b44ab66d6d0e89572b07234e346e7b8d
 
 - name: Ensure directories exist
   file:

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:5d6c5872d314e6c551d8ec1617f94367756f93121ab6102d363f87e64d4998f6
+    checksum: sha256:bcd3ae191947e55de6ee9f47ff9f68a711149d20b46ca4342aac367ded4ffc85
 
 - name: Ensure directories exist
   file:

--- a/test/main.yml
+++ b/test/main.yml
@@ -130,7 +130,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 

--- a/test/main.yml
+++ b/test/main.yml
@@ -154,6 +154,8 @@
         user: kube
         validate_certs: no
         status_code: 200
+        client_cert: "{{ cluster_config_path }}/pki/master/admin.pem"
+        client_key: "{{ cluster_config_path }}/pki/master/admin-key.pem"
 
     - name: Wait 60s for nodes to become ready
       shell: "KUBECONFIG={{ kubeconfig }} kubectl get nodes"


### PR DESCRIPTION
Updates components to
* `Kubernetes 1.14.0`
* `cni 0.6.0`
* `containerd 1.2.1`

Was unable to successfully update `runc` to `1.0.0-rc7` due to https://github.com/opencontainers/runc/pull/2031

Fixes #41  