### PR TITLE
Bump Kubernetes versions to `1.14.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.14.0
-Server Version: v1.14.0
+Client Version: v1.14.1
+Server Version: v1.14.1
 ```
 
 ## Installing additional plugins
@@ -101,13 +101,12 @@ To add a node to an existing cluster is as easy as adding it to the [inventory](
 | ------------------------- | --------- | ---------- |
 | cni                       | 0.7.5     | node       |
 | containerd                | 1.2.5     | node       |
-| etcd                      | 3.3.12     | etcd       |
-| kube-apiserver            | 1.14.0    | master     |
-| kube-controller-manager   | 1.14.0    | master     |
-| kube-scheduler            | 1.14.0    | master     |
-| kube-proxy                | 1.14.0    | node       |
-| kubelet                   | 1.14.0    | node       |
-| kubectl                   | 1.14.0    | controller |
+| etcd                      | 3.3.12    | etcd       |
+| kube-apiserver            | 1.14.1    | master     |
+| kube-controller-manager   | 1.14.1    | master     |
+| kube-scheduler            | 1.14.1    | master     |
+| kube-proxy                | 1.14.1    | node       |
+| kubelet                   | 1.14.1    | node       |
 | runc                      | 1.0.0-rc6 | node       |
 
 # How to contribute

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:6a27afb355a9dda9dddcdbe3c2d031a5c843036cdc2f453841992c111978e008
+    checksum: sha256:1ce67dda7b125dc1adadc10ab93fe339f6ce40211ae4f1552d6de177e36a430d
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:00386973f990bfd90fbd944a02111d0b92179ed7612414e1aa7f836dd177659e
+    checksum: sha256:a6028a53751ba1a9e85de094b4cc45d1971a7e339267f456b366664acee0f30f
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:21fa27ad16f56b28fa6d57a8be84174fd93daf6ccf90a1f40e3924df0fe69468
+    checksum: sha256:c374b63498f6be40f37a34bc77603e40ceba2fac0f06e1296a0065538f3a31de
 
 - name: Ensure directories exist
   file:

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:860f3bfbf81c7e5834fc6db1806a54c0b44ab66d6d0e89572b07234e346e7b8d
+    checksum: sha256:ccee8b9c60e018253399dc2eb47f6962d9e21e120cd6afed2fdda0b3c896c935
 
 - name: Ensure directories exist
   file:

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:bcd3ae191947e55de6ee9f47ff9f68a711149d20b46ca4342aac367ded4ffc85
+    checksum: sha256:c9f08323107a960b9ce075f1bee116dc9cedf7a5faea54e96ecfaf6399f6e5a3
 
 - name: Ensure directories exist
   file:

--- a/test/main.yml
+++ b/test/main.yml
@@ -130,7 +130,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 


### PR DESCRIPTION
I never upgraded from `1.13.1` to `1.14.0`, i went straight to `1.14.1` using the changes of this pull request.

I do want to highlight that it didn't go as smooth as I'd like. Everything went as expected until the end of the playbook. My NGINX ingress controllers all went down for a short period. I have a hard time figuring out why.

I see these events in my NGINX ingress controller pods:
```
Warning  Unhealthy  7m23s  kubelet, k8s-nginx-11  Readiness probe failed: HTTP probe failed with statuscode: 500
```

And I see logs like this from the pods:
```
Received SIGTERM, shutting down
k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:153: watch of *v1.Service ended with: too old resource version: 18603171 (18603183)
```

I believe the `SIGTERM` comes from the readiness probe returning 500, but I can't find any indications for why it would return 500. :(

I don't believe this is related to `1.14.1` though, this would probably have happened if I went to `1.14.0` too, so I think we can ignore that when we review this pull request. It would be nice to know what happened though.