### PR TITLE
Make sure upgrades are sequential

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
   - ansible-playbook test/main.yml --syntax-check
-  - ansible-playbook -b test/main.yml
+  - ansible-playbook -b -e "serial_all=50%" test/main.yml

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ During installation private certificates, public certificates and configuration 
 # Adding nodes
 To add a node to an existing cluster is as easy as adding it to the [inventory](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html) and running `install.yml` again.
 
+# Rolling upgrades
+When making changes to your cluster you might want to make sure that no more than X hosts are down at the same time. There are four Ansible variables that control this, which must be set with the `--extra-vars` switch:
+
+* `serial_etcd` controls how many hosts of type `etcd` will be handled at a time
+* `serial_masters` controls how many hosts of type `masters` will be handled at a time
+* `serial_nodes` controls how many hosts of type `nodes` will be handled at a time
+* `serial_all` controls how many hosts of a single type will be handled at a time, given that the specific one above for that type is **not** specified
+
+The default value of these variables is `-1`, indicating that everything should be executed in parallell. A value of `1` would indicate that only one host at a time will be processed. A value of `50%` indicates that half of the hosts (rounded downwards) will be handled at a time, which effectively means that for example 1/3 or 2/5 will be handled at a time.
+
+Example:
+
+```
+$ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" install.yml
+```
+
 # Version matrix
 
 | Name                      | Version   | Role       |

--- a/install.yml
+++ b/install.yml
@@ -4,16 +4,19 @@
   - certificates
 
 - hosts: etcd
+  serial: "{{ serial_etcd | default(serial_all | default(-1)) }}"
   roles:
   - etcd
 
 - hosts: masters
+  serial: "{{ serial_masters | default(serial_all | default(-1)) }}"
   roles:
   - kube-apiserver
   - kube-controller-manager
   - kube-scheduler
 
 - hosts: nodes
+  serial: "{{ serial_nodes | default(serial_all | default(-1)) }}"
   roles:
   - cni
   - containerd

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: True
+  with_items: "{{ groups['etcd'] }}"
+
 - set_fact:
     cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
     

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: True
+  with_items: "{{ groups['etcd'] }}"
+
 - set_fact:
     cluster_port: "{{ cluster_port | default('6443') }}"
     cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"


### PR DESCRIPTION
This way, we won't stop for example the API server or `kube-proxy` on all
masters or nodes at the same time, causing downtime.

To do:
* [ ] Wait for `containerd` to start (see #47)
* [x] Verify that running the playbook work without downtime
* [ ] Verify that actual upgrades work without downtime (I guess we can try this with `1.14.3` or `1.15.0-rc.1`)

Discussions:
* Are the delays and timeouts OK? 5 second before start checking, then check each second and timeout after 30 seconds.
* Should these be configurable with Ansible parameters?