### PR TITLE
Wrap `cluster_name` in single qoutes in generated `kubeconfig`

### DIFF
--- a/roles/certificates/templates/admin.kubeconfig
+++ b/roles/certificates/templates/admin.kubeconfig
@@ -3,17 +3,17 @@ clusters:
 - cluster:
     certificate-authority-data: {{ certificate_authority_data }}
     server: https://{{ cluster_hostname }}:{{ cluster_port }}
-  name: {{ cluster_name }}
+  name: '{{ cluster_name }}'
 contexts:
 - context:
-    cluster: {{ cluster_name }}
-    user: {{ cluster_name }}
-  name: {{ cluster_name }}
-current-context: {{ cluster_name }}
+    cluster: '{{ cluster_name }}'
+    user: '{{ cluster_name }}'
+  name: '{{ cluster_name }}'
+current-context: '{{ cluster_name }}'
 kind: Config
 preferences: {}
 users:
-- name: {{ cluster_name }}
+- name: '{{ cluster_name }}'
   user:
     client-certificate-data: {{ client_certificate_data }}
     client-key-data: {{ client_key_data }}


### PR DESCRIPTION
We don't know what value `cluster_name` might contain. If the value contains digits only, or the value
`true` or `false`, this change will avoid building a broken `kubeconfig`.

**Background:**
I tested creating a cluster real quick, and I didn't set a `cluster_name` and I used an IP address for my host instead of a hostname. It picked `192` (which makes sense) as the `cluster_name`. This is interpreted as an integer in YAML, causing a broken `kubeconfig`.

This change is close to useless, but I figured why not. :P It avoids annoying issues if people just try this playbook real quick.