### PR TITLE
Update containerd `config.toml` with non-deprecated config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,17 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 
 # Version matrix
 
-| Name                      | Version   | Role       |
-| ------------------------- | --------- | ---------- |
-| cni                       | 0.7.5     | node       |
-| containerd                | 1.2.5     | node       |
-| etcd                      | 3.3.12    | etcd       |
-| kube-apiserver            | 1.14.4    | master     |
-| kube-controller-manager   | 1.14.4    | master     |
-| kube-scheduler            | 1.14.4    | master     |
-| kube-proxy                | 1.14.4    | node       |
-| kubelet                   | 1.14.4    | node       |
-| runc                      | 1.0.0-rc6 | node       |
+| Name                      | Version    | Role       |
+| ------------------------- | ---------- | ---------- |
+| cni                       | 0.7.5      | node       |
+| containerd                | 1.3.3      | node       |
+| etcd                      | 3.3.12     | etcd       |
+| kube-apiserver            | 1.14.4     | master     |
+| kube-controller-manager   | 1.14.4     | master     |
+| kube-scheduler            | 1.14.4     | master     |
+| kube-proxy                | 1.14.4     | node       |
+| kubelet                   | 1.14.4     | node       |
+| runc                      | 1.0.0-rc10 | node       |
 
 # How to contribute
 This project is MIT licensed and accepts contributions via GitHub pull requests.

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Download containerd
   unarchive:
-    src: https://github.com/containerd/containerd/releases/download/v1.2.5/containerd-1.2.5.linux-amd64.tar.gz
+    src: https://github.com/containerd/containerd/releases/download/v1.3.3/containerd-1.3.3.linux-amd64.tar.gz
     dest: /usr/local/
     remote_src: True
   notify:

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -1,18 +1,1 @@
-[plugins]
-  [plugins.cri.containerd]
-    snapshotter = "overlayfs"
-    [plugins.cri.containerd.default_runtime]
-      runtime_type = "io.containerd.runtime.v1.linux"
-      [plugins.cri.containerd.default_runtime.options]
-        Runtime = "/usr/local/bin/runc"
-        RuntimeRoot = ""
-    [plugins.cri.containerd.runtimes.untrusted]
-      runtime_type = "io.containerd.runtime.v1.linux"
-      [plugins.cri.containerd.runtimes.untrusted.options]
-        BinaryName = "/usr/local/bin/runsc"
-        Root = "/run/containerd/runsc"
-    [plugins.cri.containerd.runtimes.gvisor]
-      runtime_type = "io.containerd.runtime.v1.linux"
-      [plugins.cri.containerd.runtimes.gvisor.options]
-        BinaryName = "/usr/local/bin/runsc"
-        Root = "/run/containerd/runsc"
+version = 2

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -1,16 +1,18 @@
-
 [plugins]
   [plugins.cri.containerd]
     snapshotter = "overlayfs"
     [plugins.cri.containerd.default_runtime]
       runtime_type = "io.containerd.runtime.v1.linux"
-      runtime_engine = "/usr/local/bin/runc"
-      runtime_root = ""
-    [plugins.cri.containerd.untrusted_workload_runtime]
+      [plugins.cri.containerd.default_runtime.options]
+        Runtime = "/usr/local/bin/runc"
+        RuntimeRoot = ""
+    [plugins.cri.containerd.runtimes.untrusted]
       runtime_type = "io.containerd.runtime.v1.linux"
-      runtime_engine = "/usr/local/bin/runsc"
-      runtime_root = "/run/containerd/runsc"
-    [plugins.cri.containerd.gvisor]
+      [plugins.cri.containerd.runtimes.untrusted.options]
+        BinaryName = "/usr/local/bin/runsc"
+        Root = "/run/containerd/runsc"
+    [plugins.cri.containerd.runtimes.gvisor]
       runtime_type = "io.containerd.runtime.v1.linux"
-      runtime_engine = "/usr/local/bin/runsc"
-      runtime_root = "/run/containerd/runsc"
+      [plugins.cri.containerd.runtimes.gvisor.options]
+        BinaryName = "/usr/local/bin/runsc"
+        Root = "/run/containerd/runsc"

--- a/roles/runc/tasks/main.yml
+++ b/roles/runc/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Download runc
   get_url:
-    url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc6/runc.amd64
+    url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc10/runc.amd64
     dest: /usr/local/bin/runc
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:860dbff86558313caf23030f9638d1bcd7a43533f12227628f4abd678eef35c1
+    checksum: sha256:a01afd5ff47d5a2a96bea3a871fb445b432f90c249a8a5d5239b05fe0d5bee4a


### PR DESCRIPTION
Update containerd's configuration so that it does not contain any deprecated options. See https://github.com/containerd/cri/blob/release/1.2/docs/config.md
In later versions of containerd the config has changed again and needs to be updated again. Will be included in the next release