### PR TITLE
Restart services with handlers

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -4,8 +4,6 @@
   - certificates
 
 - hosts: etcd
-  vars:
-    skip_etcd_handlers: True
   roles:
   - etcd
 
@@ -22,10 +20,3 @@
   - runc
   - kube-proxy
   - kubelet
-
-- hosts: etcd,masters
-  serial: 1
-  vars:
-    skip_etcd_handlers: False
-  tasks:
-  - import_tasks: roles/etcd/handlers/main.yml

--- a/install.yml
+++ b/install.yml
@@ -1,22 +1,27 @@
 - hosts: localhost
   connection: local
   roles:
-    - certificates
+  - certificates
 
 - hosts: etcd
   roles:
-    - etcd
+  - etcd
 
 - hosts: masters
   roles:
-    - kube-apiserver
-    - kube-controller-manager
-    - kube-scheduler
+  - kube-apiserver
+  - kube-controller-manager
+  - kube-scheduler
 
 - hosts: nodes
   roles:
-    - cni
-    - containerd
-    - runc
-    - kube-proxy
-    - kubelet
+  - cni
+  - containerd
+  - runc
+  - kube-proxy
+  - kubelet
+
+- hosts: etcd
+  serial: 1
+  handlers:
+  - include: roles/etcd/handlers/main.yml

--- a/install.yml
+++ b/install.yml
@@ -4,6 +4,8 @@
   - certificates
 
 - hosts: etcd
+  vars:
+    skip_etcd_handlers: True
   roles:
   - etcd
 
@@ -21,7 +23,9 @@
   - kube-proxy
   - kubelet
 
-- hosts: etcd
+- hosts: etcd,masters
   serial: 1
-  handlers:
-  - include: roles/etcd/handlers/main.yml
+  vars:
+    skip_etcd_handlers: False
+  tasks:
+  - import_tasks: roles/etcd/handlers/main.yml

--- a/roles/containerd/handlers/main.yml
+++ b/roles/containerd/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: restart containerd
+  systemd:
+    name: containerd
+    state: restarted
+  notify:
+  - wait until containerd is up
+
+- name: wait until containerd is up
+  wait_for:
+    path: /run/containerd/containerd.sock
+    state: present
+    delay: 3

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -12,23 +12,25 @@
     src: https://github.com/containerd/containerd/releases/download/v1.2.5/containerd-1.2.5.linux-amd64.tar.gz
     dest: /usr/local/
     remote_src: True
+  notify:
+    - restart containerd
 
 - name: Create configuration
   template:
     src: config.toml.j2
     dest: /etc/containerd/config.toml
+  notify:
+    - restart containerd    
 
 - name: Create systemd unit file
   template:
     src: containerd.service.j2
     dest: /etc/systemd/system/containerd.service
+  notify:
+    - restart containerd
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable containerd
-  systemd:
     name: containerd
-    state: restarted
+    daemon_reload: True
     enabled: True

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart etcd
+  systemd:
+    name: etcd
+    state: restarted

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -3,3 +3,9 @@
   systemd:
     name: etcd
     state: restarted
+  when: (not skip_etcd_handlers | default(False) | bool)
+
+- name: Wait until etcd is up
+  wait_for:
+    port: 2379
+    delay: 3

--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -3,9 +3,10 @@
   systemd:
     name: etcd
     state: restarted
-  when: (not skip_etcd_handlers | default(False) | bool)
+  notify:
+  - wait until etcd is up
 
-- name: Wait until etcd is up
+- name: wait until etcd is up
   wait_for:
     port: 2379
     delay: 3

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -35,6 +35,8 @@
   with_items:
     - etcd
     - etcdctl
+  notify:
+    - restart etcd
 
 - name: Remove tmp download files
   file:
@@ -64,18 +66,20 @@
   copy:
     src: "{{ cluster_config_path }}/pki/etcd/"
     dest: /etc/etcd/pki
+  notify:
+    - restart etcd
 
 - name: Create systemd unit file
   template:
     src: etcd.service.j2
     dest: /etc/systemd/system/etcd.service
+  notify:
+    - restart etcd
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable etcd
-  systemd:
     name: etcd
-    state: restarted
     enabled: True
+    daemon_reload: True
+  notify:
+    - restart etcd

--- a/roles/kube-apiserver/handlers/main.yml
+++ b/roles/kube-apiserver/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart kube-apiserver
+  systemd:
+    name: kube-apiserver
+    state: restarted
+  notify:
+  - wait until kube-apiserver is up
+
+- name: wait until kube-apiserver is up
+  wait_for:
+    port: "{{ cluster_port }}"
+    delay: 3

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -22,6 +22,8 @@
     owner: root
     group: root
     checksum: sha256:1ce67dda7b125dc1adadc10ab93fe339f6ce40211ae4f1552d6de177e36a430d
+  notify:
+    - restart kube-apiserver
 
 - name: Ensure directories exist
   file:
@@ -43,6 +45,8 @@
     - "{{ cluster_config_path }}/pki/master/apiserver-key.pem"
     - "{{ cluster_config_path }}/pki/master/kubelet-peer.pem"
     - "{{ cluster_config_path }}/pki/master/kubelet-peer-key.pem"
+  notify:
+    - restart kube-apiserver
 
 - name: Ensure directories exist
   file:
@@ -60,23 +64,27 @@
     - "{{ cluster_config_path }}/pki/etcd/ca.pem"
     - "{{ cluster_config_path }}/pki/etcd/etcd.pem"
     - "{{ cluster_config_path }}/pki/etcd/etcd-key.pem"
+  notify:
+    - restart kube-apiserver
 
 - name: Copy encryption-config
   copy:
     src: encryption-config.yml
     dest: /etc/kubernetes/config
+  notify:
+    - restart kube-apiserver
 
 - name: Create systemd unit file
   template:
     src: kube-apiserver.service.j2
     dest: /etc/systemd/system/kube-apiserver.service
+  notify:
+    - restart kube-apiserver
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable kube-apiserver
-  systemd:
     name: kube-apiserver
-    state: restarted
+    daemon_reload: True
     enabled: True
+  notify:
+    - restart kube-apiserver

--- a/roles/kube-controller-manager/handlers/main.yml
+++ b/roles/kube-controller-manager/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart kube-controller-manager
+  systemd:
+    name: kube-controller-manager
+    state: restarted
+  notify:
+  - wait until kube-controller-manager is up
+
+- name: wait until kube-controller-manager is up
+  wait_for:
+    port: 10257
+    delay: 3

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -22,6 +22,8 @@
     owner: root
     group: root
     checksum: sha256:a6028a53751ba1a9e85de094b4cc45d1971a7e339267f456b366664acee0f30f
+  notify:
+    - restart kube-controller-manager
 
 - name: Ensure directories exist
   file:
@@ -42,6 +44,8 @@
     - "{{ cluster_config_path }}/pki/master/kube-controller-manager.pem"
     - "{{ cluster_config_path }}/pki/master/kube-controller-manager-key.pem"
     - "{{ cluster_config_path }}/pki/master/service-account-key.pem"
+  notify:
+    - restart kube-controller-manager
 
 - name: Create kubeconfig
   template:
@@ -51,18 +55,20 @@
     certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
     client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-controller-manager.pem') | b64encode }}"
     client_key_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-controller-manager-key.pem') | b64encode }}"
+  notify:
+    - restart kube-controller-manager    
 
 - name: Create systemd unit file
   template:
     src: kube-controller-manager.service.j2
     dest: /etc/systemd/system/kube-controller-manager.service
+  notify:
+    - restart kube-controller-manager
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable kube-controller-manager
-  systemd:
     name: kube-controller-manager
-    state: restarted
+    daemon_reload: True
     enabled: True
+  notify:
+    - restart kube-controller-manager

--- a/roles/kube-proxy/handlers/main.yml
+++ b/roles/kube-proxy/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart kube-proxy
+  systemd:
+    name: kube-proxy
+    state: restarted
+  notify:
+  - wait until kube-proxy is up
+
+- name: wait until kube-proxy is up
+  wait_for:
+    port: 10256
+    delay: 3

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -21,6 +21,8 @@
     owner: root
     group: root
     checksum: sha256:c374b63498f6be40f37a34bc77603e40ceba2fac0f06e1296a0065538f3a31de
+  notify:
+    - restart kube-proxy
 
 - name: Ensure directories exist
   file:
@@ -39,6 +41,8 @@
     - "{{ cluster_config_path }}/pki/master/ca.pem"
     - "{{ cluster_config_path }}/pki/master/kube-proxy.pem"
     - "{{ cluster_config_path }}/pki/master/kube-proxy-key.pem"
+  notify:
+    - restart kube-proxy
 
 - name: Create kubeconfig
   template:
@@ -48,23 +52,27 @@
     certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
     client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-proxy.pem') | b64encode }}"
     client_key_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-proxy-key.pem') | b64encode }}"
+  notify:
+    - restart kube-proxy
 
 - name: Copy kube-proxy config
   copy:
     src: kube-proxy.yml
     dest: /etc/kubernetes/config/
+  notify:
+    - restart kube-proxy
 
 - name: Create systemd unit file
   template:
     src: kube-proxy.service.j2
     dest: /etc/systemd/system/kube-proxy.service
+  notify:
+    - restart kube-proxy
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable kube-proxy
-  systemd:
     name: kube-proxy
-    state: restarted
+    daemon_reload: True
     enabled: True
+  notify:
+    - restart kube-proxy

--- a/roles/kube-scheduler/handlers/main.yml
+++ b/roles/kube-scheduler/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart kube-scheduler
+  systemd:
+    name: kube-scheduler
+    state: restarted
+  notify:
+  - wait until kube-scheduler is up
+
+- name: wait until kube-scheduler is up
+  wait_for:
+    port: 10259
+    delay: 3

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -21,6 +21,8 @@
     owner: root
     group: root
     checksum: sha256:ccee8b9c60e018253399dc2eb47f6962d9e21e120cd6afed2fdda0b3c896c935
+  notify:
+    - restart kube-scheduler
 
 - name: Ensure directories exist
   file:
@@ -39,6 +41,8 @@
     - "{{ cluster_config_path }}/pki/master/ca.pem"
     - "{{ cluster_config_path }}/pki/master/kube-scheduler.pem"
     - "{{ cluster_config_path }}/pki/master/kube-scheduler-key.pem"
+  notify:
+    - restart kube-scheduler
 
 - name: Create kubeconfig
   template:
@@ -48,23 +52,27 @@
     certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
     client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-scheduler.pem') | b64encode }}"
     client_key_data: "{{ lookup('file', cluster_config_path+'/pki/master/kube-scheduler-key.pem') | b64encode }}"
+  notify:
+    - restart kube-scheduler
 
 - name: Copy scheduler config
   copy:
     src: kube-scheduler.yml
     dest: /etc/kubernetes/config/
+  notify:
+    - restart kube-scheduler
 
 - name: Create systemd unit file
   template:
     src: kube-scheduler.service.j2
     dest: /etc/systemd/system/kube-scheduler.service
+  notify:
+    - restart kube-scheduler
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable kube-scheduler
-  systemd:
     name: kube-scheduler
-    state: restarted
+    daemon_reload: True
     enabled: True
+  notify:
+    - restart kube-scheduler

--- a/roles/kubelet/handlers/main.yml
+++ b/roles/kubelet/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart kubelet
+  systemd:
+    name: kubelet
+    state: restarted
+  notify:
+  - wait until kubelet is up
+
+- name: wait until kubelet is up
+  wait_for:
+    port: 10250
+    delay: 3

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -21,6 +21,8 @@
     owner: root
     group: root
     checksum: sha256:c9f08323107a960b9ce075f1bee116dc9cedf7a5faea54e96ecfaf6399f6e5a3
+  notify:
+    - restart kubelet
 
 - name: Ensure directories exist
   file:
@@ -38,6 +40,8 @@
   with_fileglob:
     - "{{ cluster_config_path }}/pki/node/system:node:{{ inventory_hostname }}*"
     - "{{ cluster_config_path }}/pki/master/ca.pem"
+  notify:
+    - restart kubelet
 
 - name: Create kubeconfig
   template:
@@ -47,23 +51,27 @@
     certificate_authority_data: "{{ lookup('file', cluster_config_path+'/pki/master/ca.pem') | b64encode }}"
     client_certificate_data: "{{ lookup('file', cluster_config_path+'/pki/node/system:node:'+inventory_hostname+'.pem') | b64encode }}"
     client_key_data: "{{ lookup('file', cluster_config_path+'/pki/node/system:node:'+inventory_hostname+'-key.pem') | b64encode }}"
+  notify:
+    - restart kubelet
 
 - name: Create kubelet config
   template:
     src: kubelet.yml.j2
     dest: "/etc/kubernetes/config/system:node:{{ inventory_hostname }}.yml"
+  notify:
+    - restart kubelet
 
 - name: Create systemd unit file
   template:
     src: kubelet.service.j2
     dest: /etc/systemd/system/kubelet.service
+  notify:
+    - restart kubelet
 
 - name: daemon-reload
   systemd: 
-    daemon_reload: True
-
-- name: Start and enable kubelet
-  systemd:
     name: kubelet
-    state: restarted
+    daemon_reload: True
     enabled: True
+  notify:
+    - restart kubelet

--- a/test/main.yml
+++ b/test/main.yml
@@ -21,7 +21,9 @@
           ipv4_address: 172.19.0.2
       etc_hosts:
         kube-master: 172.19.0.3
-        kube-node1: 172.19.0.4
+        kube-node01: 172.19.0.4
+        kube-node02: 172.19.0.5
+        kube-node03: 172.19.0.6
       volumes:
         - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
@@ -36,24 +38,27 @@
           ipv4_address: 172.19.0.3
       etc_hosts:
         etcd: 172.19.0.2
-        kube-node1: 172.19.0.4
+        kube-node01: 172.19.0.4
+        kube-node02: 172.19.0.5
+        kube-node03: 172.19.0.6
       volumes:
         - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
   - name: Bring up nodes
     docker_container:
-      name: kube-node1
+      name: "{{ 'kube-node%02d' | format(item)}}"
       image: 'centos/systemd:latest'
       privileged: yes
-      hostname: kube-node1
+      hostname: "{{ 'kube-node%02d' | format(item) }}"
       etc_hosts:
         etcd: 172.19.0.2
         kube-master: 172.19.0.3
       networks:
         - name: docker_test_net
-          ipv4_address: 172.19.0.4
+          ipv4_address: "{{ '172.19.0.%d' | format(3+item) }}"
       volumes:
         - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    loop: "{{ range(1, 3+1, 1) | list }}"
         
 # Compose the inventory 
 - hosts: localhost
@@ -86,7 +91,9 @@
         ansible_become: yes
       with_items:
         - kube-master
-        - kube-node1
+        - kube-node01
+        - kube-node02
+        - kube-node03
 
 # Install required packages
 - hosts: etcd,masters,nodes
@@ -110,88 +117,88 @@
 - name: Run install.yml
   import_playbook: ../install.yml
 
-# Run Smoke tests
-- name: Smoke tests
-  hosts: localhost
-  tasks:
+# # Run Smoke tests
+# - name: Smoke tests
+#   hosts: localhost
+#   tasks:
 
-    - set_fact:
-        cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
-        config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
+#     - set_fact:
+#         cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
+#         config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
 
-    - set_fact:
-        cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
+#     - set_fact:
+#         cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
-    - set_fact:
-        cluster_config_path: "{{ config_path }}/{{ cluster_name }}"
+#     - set_fact:
+#         cluster_config_path: "{{ config_path }}/{{ cluster_name }}"
 
-    - set_fact:
-        kubeconfig: '{{ cluster_config_path }}/kubeconfig'
+#     - set_fact:
+#         kubeconfig: '{{ cluster_config_path }}/kubeconfig'
 
-    - name: Get kubectl
-      get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl
-        dest: /usr/local/bin/kubectl
-        mode: 0755
+#     - name: Get kubectl
+#       get_url:
+#         url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl
+#         dest: /usr/local/bin/kubectl
+#         mode: 0755
 
-    - name: Get IP address of kube-master container
-      shell: "docker inspect --format '{''{ .NetworkSettings.IPAddress }''}' kube-master"
-      register: result
+#     - name: Get IP address of kube-master container
+#       shell: "docker inspect --format '{''{ .NetworkSettings.IPAddress }''}' kube-master"
+#       register: result
 
-    - name: Add kube-master to /etc/hosts
-      become: True
-      lineinfile:
-        path: /etc/hosts
-        regexp: '^.*kube-master'
-        line: "{{ result.stdout }} kube-master"
-        owner: root
-        group: root
-        mode: 0644
+#     - name: Add kube-master to /etc/hosts
+#       become: True
+#       lineinfile:
+#         path: /etc/hosts
+#         regexp: '^.*kube-master'
+#         line: "{{ result.stdout }} kube-master"
+#         owner: root
+#         group: root
+#         mode: 0644
 
-    - name: Verify kube-apiserver 
-      uri:
-        url: "https://kube-master:6443/api/v1"
-        user: kube
-        validate_certs: no
-        status_code: 200
-        client_cert: "{{ cluster_config_path }}/pki/master/admin.pem"
-        client_key: "{{ cluster_config_path }}/pki/master/admin-key.pem"
+#     - name: Verify kube-apiserver 
+#       uri:
+#         url: "https://kube-master:6443/api/v1"
+#         user: kube
+#         validate_certs: no
+#         status_code: 200
+#         client_cert: "{{ cluster_config_path }}/pki/master/admin.pem"
+#         client_key: "{{ cluster_config_path }}/pki/master/admin-key.pem"
 
-    - name: Wait 60s for nodes to become ready
-      shell: "KUBECONFIG={{ kubeconfig }} kubectl get nodes"
-      register: result
-      until: result.stdout.find("NotReady") == -1
-      retries: 30
-      delay: 2
+#     - name: Wait 60s for nodes to become ready
+#       shell: "KUBECONFIG={{ kubeconfig }} kubectl get nodes"
+#       register: result
+#       until: result.stdout.find("NotReady") == -1
+#       retries: 30
+#       delay: 2
 
-    - name: Get namespace
-      shell: "kubectl get namespace ktrw-tests"
-      register: result
-      ignore_errors: True
-      no_log: True
+#     - name: Get namespace
+#       shell: "kubectl get namespace ktrw-tests"
+#       register: result
+#       ignore_errors: True
+#       no_log: True
 
-    - name: Create namespace
-      shell: "kubectl create ns ktrw-tests"
-      when: '"NotFound" in result.stderr'
+#     - name: Create namespace
+#       shell: "kubectl create ns ktrw-tests"
+#       when: '"NotFound" in result.stderr'
 
-# Run cleanup.yml
-- name: Run cleanup.yml
-  import_playbook: ../cleanup.yml
+# # Run cleanup.yml
+# - name: Run cleanup.yml
+#   import_playbook: ../cleanup.yml
 
-# Cleanup tests
-- hosts: localhost
-  tasks:
-  - name: Stop and remove containers
-    docker_container:
-      name: "{{ item }}"
-      image: 'centos/systemd:latest'
-      state: stopped
-    with_items:
-      - etcd
-      - kube-master
-      - kube-node1
+# # Cleanup tests
+# - hosts: localhost
+#   tasks:
+#   - name: Stop and remove containers
+#     docker_container:
+#       name: "{{ item }}"
+#       image: 'centos/systemd:latest'
+#       state: stopped
+#     with_items:
+#       - etcd
+#       - kube-master
+#       - kube-node1
 
-  - name: Remove network
-    docker_network:
-      name: docker_test_net
-      state: absent
+#   - name: Remove network
+#     docker_network:
+#       name: docker_test_net
+#       state: absent

--- a/test/main.yml
+++ b/test/main.yml
@@ -117,88 +117,88 @@
 - name: Run install.yml
   import_playbook: ../install.yml
 
-# # Run Smoke tests
-# - name: Smoke tests
-#   hosts: localhost
-#   tasks:
+# Run Smoke tests
+- name: Smoke tests
+  hosts: localhost
+  tasks:
 
-#     - set_fact:
-#         cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
-#         config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
+    - set_fact:
+        cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
+        config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
 
-#     - set_fact:
-#         cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
+    - set_fact:
+        cluster_name: "{{ cluster_name | default(cluster_hostname.split('.')[0] | default('kubernetes')) }}"
 
-#     - set_fact:
-#         cluster_config_path: "{{ config_path }}/{{ cluster_name }}"
+    - set_fact:
+        cluster_config_path: "{{ config_path }}/{{ cluster_name }}"
 
-#     - set_fact:
-#         kubeconfig: '{{ cluster_config_path }}/kubeconfig'
+    - set_fact:
+        kubeconfig: '{{ cluster_config_path }}/kubeconfig'
 
-#     - name: Get kubectl
-#       get_url:
-#         url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl
-#         dest: /usr/local/bin/kubectl
-#         mode: 0755
+    - name: Get kubectl
+      get_url:
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl
+        dest: /usr/local/bin/kubectl
+        mode: 0755
 
-#     - name: Get IP address of kube-master container
-#       shell: "docker inspect --format '{''{ .NetworkSettings.IPAddress }''}' kube-master"
-#       register: result
+    - name: Get IP address of kube-master container
+      shell: "docker inspect --format '{''{ .NetworkSettings.IPAddress }''}' kube-master"
+      register: result
 
-#     - name: Add kube-master to /etc/hosts
-#       become: True
-#       lineinfile:
-#         path: /etc/hosts
-#         regexp: '^.*kube-master'
-#         line: "{{ result.stdout }} kube-master"
-#         owner: root
-#         group: root
-#         mode: 0644
+    - name: Add kube-master to /etc/hosts
+      become: True
+      lineinfile:
+        path: /etc/hosts
+        regexp: '^.*kube-master'
+        line: "{{ result.stdout }} kube-master"
+        owner: root
+        group: root
+        mode: 0644
 
-#     - name: Verify kube-apiserver 
-#       uri:
-#         url: "https://kube-master:6443/api/v1"
-#         user: kube
-#         validate_certs: no
-#         status_code: 200
-#         client_cert: "{{ cluster_config_path }}/pki/master/admin.pem"
-#         client_key: "{{ cluster_config_path }}/pki/master/admin-key.pem"
+    - name: Verify kube-apiserver 
+      uri:
+        url: "https://kube-master:6443/api/v1"
+        user: kube
+        validate_certs: no
+        status_code: 200
+        client_cert: "{{ cluster_config_path }}/pki/master/admin.pem"
+        client_key: "{{ cluster_config_path }}/pki/master/admin-key.pem"
 
-#     - name: Wait 60s for nodes to become ready
-#       shell: "KUBECONFIG={{ kubeconfig }} kubectl get nodes"
-#       register: result
-#       until: result.stdout.find("NotReady") == -1
-#       retries: 30
-#       delay: 2
+    - name: Wait 60s for nodes to become ready
+      shell: "KUBECONFIG={{ kubeconfig }} kubectl get nodes"
+      register: result
+      until: result.stdout.find("NotReady") == -1
+      retries: 30
+      delay: 2
 
-#     - name: Get namespace
-#       shell: "kubectl get namespace ktrw-tests"
-#       register: result
-#       ignore_errors: True
-#       no_log: True
+    - name: Get namespace
+      shell: "kubectl get namespace ktrw-tests"
+      register: result
+      ignore_errors: True
+      no_log: True
 
-#     - name: Create namespace
-#       shell: "kubectl create ns ktrw-tests"
-#       when: '"NotFound" in result.stderr'
+    - name: Create namespace
+      shell: "kubectl create ns ktrw-tests"
+      when: '"NotFound" in result.stderr'
 
-# # Run cleanup.yml
-# - name: Run cleanup.yml
-#   import_playbook: ../cleanup.yml
+# Run cleanup.yml
+- name: Run cleanup.yml
+  import_playbook: ../cleanup.yml
 
-# # Cleanup tests
-# - hosts: localhost
-#   tasks:
-#   - name: Stop and remove containers
-#     docker_container:
-#       name: "{{ item }}"
-#       image: 'centos/systemd:latest'
-#       state: stopped
-#     with_items:
-#       - etcd
-#       - kube-master
-#       - kube-node1
+# Cleanup tests
+- hosts: localhost
+  tasks:
+  - name: Stop and remove containers
+    docker_container:
+      name: "{{ item }}"
+      image: 'centos/systemd:latest'
+      state: stopped
+    with_items:
+      - etcd
+      - kube-master
+      - kube-node1
 
-#   - name: Remove network
-#     docker_network:
-#       name: docker_test_net
-#       state: absent
+  - name: Remove network
+    docker_network:
+      name: docker_test_net
+      state: absent


### PR DESCRIPTION
This PR adds [Handlers](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-operations-on-change) to those roles that have servers that needs to be restarted at the end of each play. Namely:
* containerd
* kubelet
* kube-apiserver
* kube-scheduler
* kube-controller-manager