### PR TITLE
Bump Kubernetes to v1.14.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.14.1
-Server Version: v1.14.1
+Client Version: v1.14.4
+Server Version: v1.14.4
 ```
 
 ## Installing additional plugins
@@ -118,11 +118,11 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 | cni                       | 0.7.5     | node       |
 | containerd                | 1.2.5     | node       |
 | etcd                      | 3.3.12    | etcd       |
-| kube-apiserver            | 1.14.1    | master     |
-| kube-controller-manager   | 1.14.1    | master     |
-| kube-scheduler            | 1.14.1    | master     |
-| kube-proxy                | 1.14.1    | node       |
-| kubelet                   | 1.14.1    | node       |
+| kube-apiserver            | 1.14.4    | master     |
+| kube-controller-manager   | 1.14.4    | master     |
+| kube-scheduler            | 1.14.4    | master     |
+| kube-proxy                | 1.14.4    | node       |
+| kubelet                   | 1.14.4    | node       |
 | runc                      | 1.0.0-rc6 | node       |
 
 # How to contribute

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:1ce67dda7b125dc1adadc10ab93fe339f6ce40211ae4f1552d6de177e36a430d
+    checksum: sha256:72367d0d77b3233a597c30cb65c214a58900733a14dafc95cb98baabc4d9848c
   notify:
     - restart kube-apiserver
 

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:a6028a53751ba1a9e85de094b4cc45d1971a7e339267f456b366664acee0f30f
+    checksum: sha256:96420b36c8ca9091e9410b56c8cb01dac311e4fbd82e382f1070668993db82d5
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:c374b63498f6be40f37a34bc77603e40ceba2fac0f06e1296a0065538f3a31de
+    checksum: sha256:5925c9402911f581eacc2ebc81cb927452f3fd3295c2401c99f1978992b21dee
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:ccee8b9c60e018253399dc2eb47f6962d9e21e120cd6afed2fdda0b3c896c935
+    checksum: sha256:b05f449aa988e66be38cf2217cc8eb1abd89c6bb5205d71150cdca76ca4bec00
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:c9f08323107a960b9ce075f1bee116dc9cedf7a5faea54e96ecfaf6399f6e5a3
+    checksum: sha256:8e0321524ecfc0fb8bcafdfd450bde3127483cef7890c8127cc00e3ad3bcb91b
   notify:
     - restart kubelet
 

--- a/test/main.yml
+++ b/test/main.yml
@@ -140,7 +140,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 


### PR DESCRIPTION
All components are updated which includes:
* kube-apiserver
* kube-scheduler
* kube-controller-manager
* kube-proxy
* kubelet
* kubectl (for testing only)

Fixes #55