### PR TITLE
Bump Kubernetes to v1.15.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.14.4
-Server Version: v1.14.4
+Client Version: v1.15.10
+Server Version: v1.15.10
 ```
 
 ## Installing additional plugins
@@ -118,11 +118,11 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 | cni                       | 0.7.5      | node       |
 | containerd                | 1.3.3      | node       |
 | etcd                      | 3.3.12     | etcd       |
-| kube-apiserver            | 1.14.4     | master     |
-| kube-controller-manager   | 1.14.4     | master     |
-| kube-scheduler            | 1.14.4     | master     |
-| kube-proxy                | 1.14.4     | node       |
-| kubelet                   | 1.14.4     | node       |
+| kube-apiserver            | 1.15.10    | master     |
+| kube-controller-manager   | 1.15.10    | master     |
+| kube-scheduler            | 1.15.10    | master     |
+| kube-proxy                | 1.15.10    | node       |
+| kubelet                   | 1.15.10    | node       |
 | runc                      | 1.0.0-rc10 | node       |
 
 # How to contribute

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:72367d0d77b3233a597c30cb65c214a58900733a14dafc95cb98baabc4d9848c
+    checksum: sha256:fe614de445063aa5d7903eb7a8fe973f84668ed1d300f81cea42fa5c85b5c967
   notify:
     - restart kube-apiserver
 

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:96420b36c8ca9091e9410b56c8cb01dac311e4fbd82e382f1070668993db82d5
+    checksum: sha256:c4e19490602eacd3d52d2adcba8dbf9cff9e1301d49b413f3de2b336264d5e3a
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:5925c9402911f581eacc2ebc81cb927452f3fd3295c2401c99f1978992b21dee
+    checksum: sha256:6ceb07b1a3680ee5e77cb5f7750e49b9e44493c47cd4b2643bd71af1585f6bed
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:b05f449aa988e66be38cf2217cc8eb1abd89c6bb5205d71150cdca76ca4bec00
+    checksum: sha256:1d0eb8d51cd962e4e8da0ff2cf88a59c2c8cebd9efcb8e48384cfdc83d9db072
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:8e0321524ecfc0fb8bcafdfd450bde3127483cef7890c8127cc00e3ad3bcb91b
+    checksum: sha256:33859bf393da38e36d2a7fc76f6f207d75763338f057d65bef56a19be9f87ca2
   notify:
     - restart kubelet
 

--- a/test/main.yml
+++ b/test/main.yml
@@ -140,7 +140,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.14.4/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 


### PR DESCRIPTION
# Kubernetes changelog

> CNI remains unchanged at v0.7.5. (kubernetes/kubernetes#75455)

We have v0.7.5 already, so we're fine.

> Default etcd server version remains unchanged at v3.3.10. The etcd client version was updated to v3.3.10. (kubernetes/kubernetes#71615, kubernetes/kubernetes#70168, kubernetes/kubernetes#76917)

We have v3.3.12, so we must be fine! :)

I haven't found any service options that we use that has been deprecated.

# Testing
* [x] Creating a new cluster with 1.15, add basic things to the cluster (pod networking, DNS, Ingress controller and a sample deployment)
* [x] Upgrading an existing 1.14 to 1.15, expect no downtime.