### PR TITLE
Bump Kubernetes to v1.16.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.15.10
-Server Version: v1.15.10
+Client Version: v1.16.7
+Server Version: v1.16.7
 ```
 
 ## Installing additional plugins
@@ -119,12 +119,12 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 | cni                       | 0.7.5      | node       |
 | containerd                | 1.3.3      | node       |
 | crictl                    | 1.16.1     | node       |
-| etcd                      | 3.3.12     | etcd       |
-| kube-apiserver            | 1.15.10    | master     |
-| kube-controller-manager   | 1.15.10    | master     |
-| kube-scheduler            | 1.15.10    | master     |
-| kube-proxy                | 1.15.10    | node       |
-| kubelet                   | 1.15.10    | node       |
+| etcd                      | 3.3.15     | etcd       |
+| kube-apiserver            | 1.16.7     | master     |
+| kube-controller-manager   | 1.16.7     | master     |
+| kube-scheduler            | 1.16.7     | master     |
+| kube-proxy                | 1.16.7     | node       |
+| kubelet                   | 1.16.7     | node       |
 | runc                      | 1.0.0-rc10 | node       |
 
 # How to contribute

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -19,22 +19,22 @@
 
 - name: Download etcd
   get_url:
-    url: https://github.com/coreos/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz
-    dest: /tmp/etcd-v3.3.12-linux-amd64.tar.gz
+    url: https://github.com/etcd-io/etcd/releases/download/v3.3.15/etcd-v3.3.15-linux-amd64.tar.gz
+    dest: /tmp/etcd-v3.3.15-linux-amd64.tar.gz
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:dc5d82df095dae0a2970e4d870b6929590689dd707ae3d33e7b86da0f7f211b6
+    checksum: sha256:87e30dc472a48b775a9e764cb742a5df0a2844e7b82d12917d7ea489febbc8c8
 
 - name: Unarchive etcd tarball
   unarchive:
-    src: /tmp/etcd-v3.3.12-linux-amd64.tar.gz
+    src: /tmp/etcd-v3.3.15-linux-amd64.tar.gz
     dest: /tmp
     remote_src: True
 
 - name: Move etcd binaries into place
   copy:
-    src: "/tmp/etcd-v3.3.12-linux-amd64/{{ item }}"
+    src: "/tmp/etcd-v3.3.15-linux-amd64/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     remote_src: True
   with_items:
@@ -48,8 +48,8 @@
     path: "/tmp/{{ item }}"
     state: absent
   with_items:
-    - etcd-v3.3.12-linux-amd64
-    - etcd-v3.3.12-linux-amd64.tar.gz
+    - etcd-v3.3.15-linux-amd64
+    - etcd-v3.3.15-linux-amd64.tar.gz
 
 - name: Make etcd binaries executable
   file:

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:fe614de445063aa5d7903eb7a8fe973f84668ed1d300f81cea42fa5c85b5c967
+    checksum: sha256:aa2a4adef0ce70e2d0524e38dc544fb2211ba3a2fa9292ca30c6a4d01cb10f42
   notify:
     - restart kube-apiserver
 

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:c4e19490602eacd3d52d2adcba8dbf9cff9e1301d49b413f3de2b336264d5e3a
+    checksum: sha256:ff31b0507c67e94b1bf8af580029e4dde330a9ef81474d64b4cc54e85a4ce4a3
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:6ceb07b1a3680ee5e77cb5f7750e49b9e44493c47cd4b2643bd71af1585f6bed
+    checksum: sha256:a96c8ff94252e6d5ac4ce84e5ce6933e9a7f61fc0f11ac7a21297f45e149831b
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:1d0eb8d51cd962e4e8da0ff2cf88a59c2c8cebd9efcb8e48384cfdc83d9db072
+    checksum: sha256:a05d8c8dde761dd0d1bea17e57bc30b27cd34de9b5ee36d82cad4584e46e1219
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:33859bf393da38e36d2a7fc76f6f207d75763338f057d65bef56a19be9f87ca2
+    checksum: sha256:f49755b06848914c2729353d3580199a70ec8d732609660e90214b4f48ff4398
   notify:
     - restart kubelet
 

--- a/test/main.yml
+++ b/test/main.yml
@@ -140,7 +140,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.15.10/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 


### PR DESCRIPTION
# Kubernetes changelog

> CNI remains unchanged at v0.7.5. (kubernetes/kubernetes#75455)

We have v0.7.5 already, so we're fine.

> etcd has been updated to v3.3.15 (kubernetes/kubernetes#82199, @ dims)

We currently have v3.3.12. I've bumped to v3.3.15 in this PR.

I haven't found any service options that we use that has been deprecated.

# Testing
* [x] Creating a new cluster with 1.16, add basic things to the cluster (pod networking, DNS, Ingress controller and a sample deployment)
* [x] Upgrading an existing 1.15 to 1.16, expect no downtime.