### PR TITLE
Install `crictl` on nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 | ------------------------- | ---------- | ---------- |
 | cni                       | 0.7.5      | node       |
 | containerd                | 1.3.3      | node       |
+| crictl                    | 1.16.1     | node       |
 | etcd                      | 3.3.12     | etcd       |
 | kube-apiserver            | 1.15.10    | master     |
 | kube-controller-manager   | 1.15.10    | master     |

--- a/install.yml
+++ b/install.yml
@@ -20,6 +20,7 @@
   roles:
   - cni
   - containerd
+  - crictl
   - runc
   - kube-proxy
   - kubelet

--- a/roles/crictl/tasks/main.yml
+++ b/roles/crictl/tasks/main.yml
@@ -1,0 +1,32 @@
+- name: Download crictl
+  get_url:
+    url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.16.1/crictl-v1.16.1-linux-amd64.tar.gz
+    dest: /tmp/crictl-v1.16.1-linux-amd64.tar.gz
+    mode: 0755
+    owner: root
+    group: root
+    checksum: sha256:19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1
+
+- name: Unarchive crictl tarball
+  unarchive:
+    src: /tmp/crictl-v1.16.1-linux-amd64.tar.gz
+    dest: /tmp
+    remote_src: True
+
+- name: Move crictl binary into place
+  copy:
+    src: /tmp/crictl
+    dest: /usr/local/bin/crictl
+    remote_src: True
+
+- name: Remove tmp download files
+  file:
+    path: /tmp/crictl
+    state: absent
+
+- name: Make crictl binaries executable
+  file:
+    path: /usr/local/bin/crictl
+    owner: root
+    group: root
+    mode: 0755


### PR DESCRIPTION
Closes #64

I decided to not have this configurable for now. We can always change this if the need arises.

I also decided to use version 1.16, since we have a PR for Kubernetes 1.16 anyway (#65).