### PR TITLE
Add `TasksMax=infinity` to `containerd.service`

### DIFF
--- a/roles/containerd/templates/containerd.service.j2
+++ b/roles/containerd/templates/containerd.service.j2
@@ -14,6 +14,7 @@ OOMScoreAdjust=-999
 LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The entry `TasksMax=infinity` in `/etc/systemd/system/containerd.service` will prevent nodes from failing to run containers due to too many processes max limit. 

This parameters exists in the official [containerd/cri](https://github.com/containerd/cri) version of containerd.service: https://github.com/containerd/cri/blob/master/contrib/systemd-units/containerd.service