### PR TITLE
Bump Kubernetes to v1.16.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: stretch
+dist: xenial
 language: python
 python:
   - "2.7"

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.16.7
-Server Version: v1.16.7
+Client Version: v1.16.13
+Server Version: v1.16.13
 ```
 
 ## Installing additional plugins
@@ -120,11 +120,11 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 | containerd                | 1.3.3      | node       |
 | crictl                    | 1.16.1     | node       |
 | etcd                      | 3.3.15     | etcd       |
-| kube-apiserver            | 1.16.7     | master     |
-| kube-controller-manager   | 1.16.7     | master     |
-| kube-scheduler            | 1.16.7     | master     |
-| kube-proxy                | 1.16.7     | node       |
-| kubelet                   | 1.16.7     | node       |
+| kube-apiserver            | 1.16.13    | master     |
+| kube-controller-manager   | 1.16.13    | master     |
+| kube-scheduler            | 1.16.13    | master     |
+| kube-proxy                | 1.16.13    | node       |
+| kubelet                   | 1.16.13    | node       |
 | runc                      | 1.0.0-rc10 | node       |
 
 # How to contribute

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:aa2a4adef0ce70e2d0524e38dc544fb2211ba3a2fa9292ca30c6a4d01cb10f42
+    checksum: sha256:ac61f2d9c0a95e901547230abd3b28262dde59250619dfcfc17f8e1632839878
   notify:
     - restart kube-apiserver
 

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:ff31b0507c67e94b1bf8af580029e4dde330a9ef81474d64b4cc54e85a4ce4a3
+    checksum: sha256:2d57d0c3a351260d1d3cd1843189a49a09aca7e7905c90b2c08b4165d1171b5e
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:a96c8ff94252e6d5ac4ce84e5ce6933e9a7f61fc0f11ac7a21297f45e149831b
+    checksum: sha256:f83dee5a2eaa86b62ac271d5b306e07420f2ab978ae757eb839c207f95186a11
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:a05d8c8dde761dd0d1bea17e57bc30b27cd34de9b5ee36d82cad4584e46e1219
+    checksum: sha256:6aed00d41867e17d6d602b623fa6f9cb5e72ba26386087f8221b3b292a7b039e
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:f49755b06848914c2729353d3580199a70ec8d732609660e90214b4f48ff4398
+    checksum: sha256:a88c0e9f8c4b5a2e91c2c4a8d772cc65ca3a0eb5d477cbce06fbf82d3e50c158
   notify:
     - restart kubelet
 

--- a/roles/runc/tasks/main.yml
+++ b/roles/runc/tasks/main.yml
@@ -6,4 +6,4 @@
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:a01afd5ff47d5a2a96bea3a871fb445b432f90c249a8a5d5239b05fe0d5bee4a
+    checksum: sha256:0fec6929f8675aa7530a7920498e8910365cc9f2867e9a31d2129defd96aa489

--- a/test/main.yml
+++ b/test/main.yml
@@ -103,7 +103,7 @@
   tasks:
 
     - yum:
-        name: ['iproute', 'libseccomp', 'libseccomp-devel', 'conntrack']
+        name: ['iproute', 'libseccomp', 'libseccomp-devel', 'conntrack', 'sudo']
         state: present
 
     - name: Remove swapfile from /etc/fstab

--- a/test/main.yml
+++ b/test/main.yml
@@ -140,7 +140,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.16.7/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 


### PR DESCRIPTION
When I upgraded one of my clusters that were utilizing `flannel` to 1.16.7 which is the latest KTRW, I hit this issue:
https://github.com/kubernetes/kubernetes/pull/92035

We use a temporary fix on our worker nodes. This real fix has been backported to a later 1.16 version, so I'd be great with this bump. I'd love this "fixed" for the cluster before I proceed to bumping to 1.17.

I figured we could create the patch release `v1.2.1` with this commit included. If you agree, do you think that the other commit since `v1.2.0` (98aac409d35731239c4eb7418dba63697045d882) should be included too?