### PR TITLE
WIP: Bump Kubernetes to v1.17.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.16.13
-Server Version: v1.16.13
+Client Version: v1.17.9
+Server Version: v1.17.9
 ```
 
 ## Installing additional plugins
@@ -116,15 +116,15 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 
 | Name                      | Version    | Role       |
 | ------------------------- | ---------- | ---------- |
-| cni                       | 0.7.5      | node       |
+| cni                       | 0.8.6      | node       |
 | containerd                | 1.3.3      | node       |
 | crictl                    | 1.16.1     | node       |
-| etcd                      | 3.3.15     | etcd       |
-| kube-apiserver            | 1.16.13    | master     |
-| kube-controller-manager   | 1.16.13    | master     |
-| kube-scheduler            | 1.16.13    | master     |
-| kube-proxy                | 1.16.13    | node       |
-| kubelet                   | 1.16.13    | node       |
+| etcd                      | 3.4.3      | etcd       |
+| kube-apiserver            | 1.17.9     | master     |
+| kube-controller-manager   | 1.17.9     | master     |
+| kube-scheduler            | 1.17.9     | master     |
+| kube-proxy                | 1.17.9     | node       |
+| kubelet                   | 1.17.9     | node       |
 | runc                      | 1.0.0-rc10 | node       |
 
 # How to contribute

--- a/roles/cni/tasks/main.yml
+++ b/roles/cni/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download cni
   unarchive:
-    src: https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz
+    src: https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz
     dest: /opt/cni/bin/
     remote_src: True
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -19,22 +19,22 @@
 
 - name: Download etcd
   get_url:
-    url: https://github.com/etcd-io/etcd/releases/download/v3.3.15/etcd-v3.3.15-linux-amd64.tar.gz
-    dest: /tmp/etcd-v3.3.15-linux-amd64.tar.gz
+    url: https://github.com/etcd-io/etcd/releases/download/v3.4.3/etcd-v3.4.3-linux-amd64.tar.gz
+    dest: /tmp/etcd-v3.4.3-linux-amd64.tar.gz
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:87e30dc472a48b775a9e764cb742a5df0a2844e7b82d12917d7ea489febbc8c8
+    checksum: sha256:6c642b723a86941b99753dff6c00b26d3b033209b15ee33325dc8e7f4cd68f07
 
 - name: Unarchive etcd tarball
   unarchive:
-    src: /tmp/etcd-v3.3.15-linux-amd64.tar.gz
+    src: /tmp/etcd-v3.4.3-linux-amd64.tar.gz
     dest: /tmp
     remote_src: True
 
 - name: Move etcd binaries into place
   copy:
-    src: "/tmp/etcd-v3.3.15-linux-amd64/{{ item }}"
+    src: "/tmp/etcd-v3.4.3-linux-amd64/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     remote_src: True
   with_items:
@@ -48,8 +48,8 @@
     path: "/tmp/{{ item }}"
     state: absent
   with_items:
-    - etcd-v3.3.15-linux-amd64
-    - etcd-v3.3.15-linux-amd64.tar.gz
+    - etcd-v3.4.3-linux-amd64
+    - etcd-v3.4.3-linux-amd64.tar.gz
 
 - name: Make etcd binaries executable
   file:

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:ac61f2d9c0a95e901547230abd3b28262dde59250619dfcfc17f8e1632839878
+    checksum: sha256:9150e452e2462bda958985b9571a0961fd21caa53ee2aad9d75c4a3e78087e19
   notify:
     - restart kube-apiserver
 

--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -13,7 +13,6 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --authorization-mode=Node,RBAC \
   --bind-address=0.0.0.0 \
   --secure-port={{ cluster_port }} \
-  --insecure-port=0 \
   --client-ca-file=/etc/kubernetes/pki/ca.pem \
   --etcd-cafile=/etc/etcd/pki/ca.pem \
   --etcd-certfile=/etc/etcd/pki/etcd.pem \

--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -22,7 +22,7 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --kubelet-certificate-authority=/etc/kubernetes/pki/ca.pem \
   --kubelet-client-certificate=/etc/kubernetes/pki/kubelet-peer.pem \
   --kubelet-client-key=/etc/kubernetes/pki/kubelet-peer-key.pem \
-  --runtime-config=api/all \
+  --runtime-config=api/all=true \
   --service-account-key-file=/etc/kubernetes/pki/service-account-key.pem \
   --service-cluster-ip-range=10.32.0.0/24 \
   --tls-cert-file=/etc/kubernetes/pki/apiserver.pem \

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:2d57d0c3a351260d1d3cd1843189a49a09aca7e7905c90b2c08b4165d1171b5e
+    checksum: sha256:936cb7aaf00453a11793772c2fad6b4ee56da4470afc8f1263516f3744fe2262
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:f83dee5a2eaa86b62ac271d5b306e07420f2ab978ae757eb839c207f95186a11
+    checksum: sha256:a122808cff4f87301c1f7ddc096a3bb2a7bee7480f0192c4ca2a9cd5e72dfee5
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:6aed00d41867e17d6d602b623fa6f9cb5e72ba26386087f8221b3b292a7b039e
+    checksum: sha256:560ec67a343fc126fb5f68a16084743f6ec7e14cfa842fa6d603df6a7f8fc2e1
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:a88c0e9f8c4b5a2e91c2c4a8d772cc65ca3a0eb5d477cbce06fbf82d3e50c158
+    checksum: sha256:3b6cdfcd38a646c7b553821ef9bb67e93541da658305c00705e6ab2ba15e73af
   notify:
     - restart kubelet
 

--- a/test/main.yml
+++ b/test/main.yml
@@ -140,7 +140,7 @@
 
     - name: Get kubectl
       get_url:
-        url: https://storage.googleapis.com/kubernetes-release/release/v1.16.13/bin/linux/amd64/kubectl
+        url: https://storage.googleapis.com/kubernetes-release/release/v1.17.9/bin/linux/amd64/kubectl
         dest: /usr/local/bin/kubectl
         mode: 0755
 


### PR DESCRIPTION
**NOTE:** Not fully tested. Do not merge.

Kubernetes changelog can be found here:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md

## Version bumps other than Kubernetes ones

### etcd

etcd was bumped from `3.3.15` to `3.4.3`, because this was found in the changelog:
> Update etcd client side to v3.4.3 (kubernetes/kubernetes#83987, @wenjiaswe)
> Update default etcd server version to 3.4.3 (kubernetes/kubernetes#84329, @jingyih)

An upgrade from 3.3 to 3.4 should be zero-downtime using a regular rolling upgrade, according to their own documentation:
https://etcd.io/docs/v3.3.12/upgrades/upgrade_3_4/

### CNI plugins

The CNI plugins was bumped from 0.7.5 to 0.8.6, because this was found in this changelog:
> Update CNI to v0.8.6

Note that this bump was performed in Kubernetes 1.17.7, but since we're bumping to 1.17.9, this feels very appropriate. :)

### Other

I don't see anything related to `runc` or `containerd` - however - we probably never see that in their changelog since there are different container runtimes. But the current versions of `containerd` and `runc` that we use are both released **after** Kubernetes 1.17, so I think we can leave these as is for now, and maybe revisit this for the 1.18 bump. Or what do you think @amimof?

## Breaking changes

I could not find any breaking changes or deprecations regarding the command line parameters to the various services (`kube-apiserver` etc).