### PR TITLE
Upgrade Kubernetes to `1.20.6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install a [Kubernetes](https://kubernetes.io/) cluster with [Ansible](https://ww
 This project aims to provide an automated way of deploying a Kubernetes cluster that isn't configured. This means that configuration and host preparations lies in the hands of the user executing the playbooks. After a successfull install you will have a cluster with:
 * [containerd](https://github.com/containerd/containerd) as container runtime
 * [runc](https://github.com/opencontainers/runc) for managing containers
-* [cni](https://github.com/containernetworking/cni) plugins
+* [cni plugins](https://github.com/containernetworking/plugins)
 * one or more [etcd](https://github.com/etcd-io/etcd) instances
 * one or more masters (kube-api, kube-controller-manager, kube-scheduler) installed as services managed by systemd.
 * one or more nodes (kubelet)
@@ -67,8 +67,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.19.8
-Server Version: v1.19.8
+Client Version: v1.20.6
+Server Version: v1.20.6
 ```
 
 ## Installing additional plugins
@@ -116,15 +116,15 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 
 | Name                      | Version    | Role       |
 | ------------------------- | ---------- | ---------- |
-| cni                       | 0.8.7      | node       |
-| containerd                | 1.3.3      | node       |
-| crictl                    | 1.19.0     | node       |
+| cni plugins               | 0.8.7      | node       |
+| containerd                | 1.4.1      | node       |
+| crictl                    | 1.20.0     | node       |
 | etcd                      | 3.4.13     | etcd       |
-| kube-apiserver            | 1.19.8     | master     |
-| kube-controller-manager   | 1.19.8     | master     |
-| kube-scheduler            | 1.19.8     | master     |
-| kube-proxy                | 1.19.8     | node       |
-| kubelet                   | 1.19.8     | node       |
+| kube-apiserver            | 1.20.6     | master     |
+| kube-controller-manager   | 1.20.6     | master     |
+| kube-scheduler            | 1.20.6     | master     |
+| kube-proxy                | 1.20.6     | node       |
+| kubelet                   | 1.20.6     | node       |
 | runc                      | 1.0.0-rc93 | node       |
 
 # How to contribute

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Download containerd
   unarchive:
-    src: https://github.com/containerd/containerd/releases/download/v1.3.3/containerd-1.3.3.linux-amd64.tar.gz
+    src: https://github.com/containerd/containerd/releases/download/v1.4.1/containerd-1.4.1-linux-amd64.tar.gz
     dest: /usr/local/
     remote_src: True
   notify:

--- a/roles/crictl/tasks/main.yml
+++ b/roles/crictl/tasks/main.yml
@@ -1,15 +1,15 @@
 - name: Download crictl
   get_url:
-    url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-amd64.tar.gz
-    dest: /tmp/crictl-v1.19.0-linux-amd64.tar.gz
+    url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz
+    dest: /tmp/crictl-v1.20.0-linux-amd64.tar.gz
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae
+    checksum: sha256:44d5f550ef3f41f9b53155906e0229ffdbee4b19452b4df540265e29572b899c
 
 - name: Unarchive crictl tarball
   unarchive:
-    src: /tmp/crictl-v1.19.0-linux-amd64.tar.gz
+    src: /tmp/crictl-v1.20.0-linux-amd64.tar.gz
     dest: /tmp
     remote_src: True
 

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.19.8/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:c75948a13379f700306f2a3cbf73d6c636f7bf6725d31dfab73086fa98407851
+    checksum: sha256:17f64a9d27676599075dfa4580326b364137fb10b6949791d257e511d5b7c601
   notify:
     - restart kube-apiserver
 
@@ -45,6 +45,7 @@
     dest: /etc/kubernetes/pki
   with_items:
     - "{{ cluster_config_path }}/pki/master/ca.pem"
+    - "{{ cluster_config_path }}/pki/master/service-account.pem"
     - "{{ cluster_config_path }}/pki/master/service-account-key.pem"
     - "{{ cluster_config_path }}/pki/master/apiserver.pem"
     - "{{ cluster_config_path }}/pki/master/apiserver-key.pem"

--- a/roles/kube-apiserver/templates/kube-apiserver.service.j2
+++ b/roles/kube-apiserver/templates/kube-apiserver.service.j2
@@ -23,7 +23,9 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --kubelet-client-certificate=/etc/kubernetes/pki/kubelet-peer.pem \
   --kubelet-client-key=/etc/kubernetes/pki/kubelet-peer-key.pem \
   --runtime-config=api/all=true \
-  --service-account-key-file=/etc/kubernetes/pki/service-account-key.pem \
+  --service-account-signing-key-file=/etc/kubernetes/pki/service-account-key.pem \
+  --service-account-key-file=/etc/kubernetes/pki/service-account.pem \
+  --service-account-issuer=api \
   --service-cluster-ip-range=10.32.0.0/24 \
   --tls-cert-file=/etc/kubernetes/pki/apiserver.pem \
   --tls-private-key-file=/etc/kubernetes/pki/apiserver-key.pem{% for flag in flags_apiserver %} \

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.19.8/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:ef6559d0c5ec782c042c791b427768909a665692b89a8725dadbd15bdd0c8739
+    checksum: sha256:f783d4734cbe8907b96c9ebc97d1a6f3a62355472281b30180cdc00ebec4bc16
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.19.8/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:15f7959b98793e4257fa6e5ad0a2ab3806a3fcd5079a8e62798fdf8d850a83d9
+    checksum: sha256:b64375f805dec9540078f3295e77bfa339227b6c3b2b63bd4239d0c4eaf0254e
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -15,12 +15,12 @@
     
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.19.8/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:d8043890091c01ad15e461ba53d6ad3cdf0579853c70149eb3e7ee7d82582be3
+    checksum: sha256:1ff832c70d5597b5ffda1d63a737855d93cde7d1233b1afb69bcd3df027b16e6
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.19.8/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:f5cad5260c29584dd370ec13e525c945866957b1aaa719f1b871c31dc30bcb3f
+    checksum: sha256:7688a663dd06222d337c8fdb5b05e1d9377e6d64aa048c6acf484bc3f2a596a8
   notify:
     - restart kubelet
 


### PR DESCRIPTION
Also upgrade `containerd` to `1.4.1`.

Note that the following two options are now required:
```
  --service-account-signing-key-file
  --service-account-issuer
```

We switched so we use the public key as `service-account-key-file` and use the private key as `service-account-signing-key-file`, as suggested by the Kubernetes documentation. It works in our upgraded cluster.