### PR TITLE
Draft: Upgrade Kubernetes to `1.25.5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ ansible-playbook -i inventory install.yml
 - Use the kubeconfig in `~/.ktrw/<cluster_name>/kubeconfig` to manage the cluster
 ```shell
 $ KUBECONFIG=~/.ktrw/<cluster_name>/kubeconfig kubectl version --short
-Client Version: v1.20.6
-Server Version: v1.20.6
+Client Version: v1.25.5
+Server Version: v1.25.5
 ```
 
 ## Installing additional plugins
@@ -116,16 +116,16 @@ $ ansible-playbook --inventory ansible-inventory --extra-vars "serial_all=50%" i
 
 | Name                      | Version    | Role       |
 | ------------------------- | ---------- | ---------- |
-| cni plugins               | 0.8.7      | node       |
-| containerd                | 1.4.1      | node       |
-| crictl                    | 1.20.0     | node       |
-| etcd                      | 3.4.13     | etcd       |
-| kube-apiserver            | 1.20.6     | master     |
-| kube-controller-manager   | 1.20.6     | master     |
-| kube-scheduler            | 1.20.6     | master     |
-| kube-proxy                | 1.20.6     | node       |
-| kubelet                   | 1.20.6     | node       |
-| runc                      | 1.0.0-rc93 | node       |
+| cni plugins               | 0.9.1      | node       |
+| containerd                | 1.6.12     | node       |
+| crictl                    | 1.25.0     | node       |
+| etcd                      | 3.5.6      | etcd       |
+| kube-apiserver            | 1.25.5     | master     |
+| kube-controller-manager   | 1.25.5     | master     |
+| kube-scheduler            | 1.25.5     | master     |
+| kube-proxy                | 1.25.5     | node       |
+| kubelet                   | 1.25.5     | node       |
+| runc                      | 1.1.1      | node       |
 
 # How to contribute
 This project is MIT licensed and accepts contributions via GitHub pull requests.

--- a/roles/cni/tasks/main.yml
+++ b/roles/cni/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download cni
   unarchive:
-    src: https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz
+    src: https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
     dest: /opt/cni/bin/
     remote_src: True
 
@@ -22,5 +22,3 @@
   template:
     src: 99-loopback.conf.j2
     dest: /etc/cni/net.d/99-loopback.conf
-
-

--- a/roles/containerd/tasks/main.yml
+++ b/roles/containerd/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Download containerd
   unarchive:
-    src: https://github.com/containerd/containerd/releases/download/v1.4.1/containerd-1.4.1-linux-amd64.tar.gz
+    src: https://github.com/containerd/containerd/releases/download/v1.6.12/containerd-1.6.12-linux-amd64.tar.gz
     dest: /usr/local/
     remote_src: True
   notify:

--- a/roles/crictl/tasks/main.yml
+++ b/roles/crictl/tasks/main.yml
@@ -1,15 +1,15 @@
 - name: Download crictl
   get_url:
-    url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz
-    dest: /tmp/crictl-v1.20.0-linux-amd64.tar.gz
+    url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.25.0/crictl-v1.25.0-linux-amd64.tar.gz
+    dest: /tmp/crictl-v1.25.0-linux-amd64.tar.gz
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:44d5f550ef3f41f9b53155906e0229ffdbee4b19452b4df540265e29572b899c
+    checksum: sha256:86ab210c007f521ac4cdcbcf0ae3fb2e10923e65f16de83e0e1db191a07f0235
 
 - name: Unarchive crictl tarball
   unarchive:
-    src: /tmp/crictl-v1.20.0-linux-amd64.tar.gz
+    src: /tmp/crictl-v1.25.0-linux-amd64.tar.gz
     dest: /tmp
     remote_src: True
 

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - set_fact:
     cluster_hostname: "{{ cluster_hostname | default(groups['masters'][0]) }}"
-    
+
 - set_fact:
     config_path: "{{ config_path | default(lookup('env','HOME')+'/.ktrw') }}"
   delegate_to: 127.0.0.1
@@ -19,22 +19,22 @@
 
 - name: Download etcd
   get_url:
-    url: https://github.com/etcd-io/etcd/releases/download/v3.4.13/etcd-v3.4.13-linux-amd64.tar.gz
-    dest: /tmp/etcd-v3.4.13-linux-amd64.tar.gz
+    url: https://github.com/etcd-io/etcd/releases/download/v3.5.6/etcd-v3.5.6-linux-amd64.tar.gz
+    dest: /tmp/etcd-v3.5.6-linux-amd64.tar.gz
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:2ac029e47bab752dacdb7b30032f230f49e2f457cbc32e8f555c2210bb5ff107
+    checksum: sha256:4db32e3bc06dd0999e2171f76a87c1cffed8369475ec7aa7abee9023635670fb
 
 - name: Unarchive etcd tarball
   unarchive:
-    src: /tmp/etcd-v3.4.13-linux-amd64.tar.gz
+    src: /tmp/etcd-v3.5.6-linux-amd64.tar.gz
     dest: /tmp
     remote_src: True
 
 - name: Move etcd binaries into place
   copy:
-    src: "/tmp/etcd-v3.4.13-linux-amd64/{{ item }}"
+    src: "/tmp/etcd-v3.5.6-linux-amd64/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     remote_src: True
   with_items:
@@ -48,8 +48,8 @@
     path: "/tmp/{{ item }}"
     state: absent
   with_items:
-    - etcd-v3.4.13-linux-amd64
-    - etcd-v3.4.13-linux-amd64.tar.gz
+    - etcd-v3.5.6-linux-amd64
+    - etcd-v3.5.6-linux-amd64.tar.gz
 
 - name: Make etcd binaries executable
   file:
@@ -60,7 +60,7 @@
   with_items:
     - etcd
     - etcdctl
-    
+
 - name: Ensure directories exist
   file:
     state: directory

--- a/roles/kube-apiserver/tasks/main.yml
+++ b/roles/kube-apiserver/tasks/main.yml
@@ -21,12 +21,12 @@
 
 - name: Download kube-apiserver
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-apiserver
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.25.5/bin/linux/amd64/kube-apiserver
     dest: /usr/local/bin/kube-apiserver
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:17f64a9d27676599075dfa4580326b364137fb10b6949791d257e511d5b7c601
+    checksum: sha256:c0ff83a8a499fbefade288411a09250c92bbb234f9961c6d7787d4ef702e6a5c
   notify:
     - restart kube-apiserver
 

--- a/roles/kube-controller-manager/tasks/main.yml
+++ b/roles/kube-controller-manager/tasks/main.yml
@@ -16,12 +16,12 @@
 
 - name: Download kube-controller-manager
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-controller-manager
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.25.5/bin/linux/amd64/kube-controller-manager
     dest: /usr/local/bin/kube-controller-manager
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:f783d4734cbe8907b96c9ebc97d1a6f3a62355472281b30180cdc00ebec4bc16
+    checksum: sha256:2fc15014c2fcbe5277ffae17e6b8463af0e4300b490e516d94ecccf1f6e9572a
   notify:
     - restart kube-controller-manager
 

--- a/roles/kube-proxy/tasks/main.yml
+++ b/roles/kube-proxy/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kube-proxy
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-proxy
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.25.5/bin/linux/amd64/kube-proxy
     dest: /usr/local/bin/kube-proxy
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:b64375f805dec9540078f3295e77bfa339227b6c3b2b63bd4239d0c4eaf0254e
+    checksum: sha256:5fbd75670ae832b28023e986ec9bcf0d18450da62c1d9e0a62d741ba55c28d4e
   notify:
     - restart kube-proxy
 

--- a/roles/kube-scheduler/tasks/main.yml
+++ b/roles/kube-scheduler/tasks/main.yml
@@ -12,15 +12,15 @@
 
 - set_fact:
     cluster_config_path: "{{ config_path }}/{{ cluster_name }}"
-    
+
 - name: Download kube-scheduler
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kube-scheduler
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.25.5/bin/linux/amd64/kube-scheduler
     dest: /usr/local/bin/kube-scheduler
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:1ff832c70d5597b5ffda1d63a737855d93cde7d1233b1afb69bcd3df027b16e6
+    checksum: sha256:72146943b4310ef8ccab16a195fd2a916feebafdac2bf6544db747fc2419254f
   notify:
     - restart kube-scheduler
 

--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -15,12 +15,12 @@
 
 - name: Download kubelet
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/linux/amd64/kubelet
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.25.5/bin/linux/amd64/kubelet
     dest: /usr/local/bin/kubelet
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:7688a663dd06222d337c8fdb5b05e1d9377e6d64aa048c6acf484bc3f2a596a8
+    checksum: sha256:n16b23e1254830805b892cfccf2687eb3edb4ea54ffbadb8cc2eee6d3b1fab8e6
   notify:
     - restart kubelet
 

--- a/roles/runc/tasks/main.yml
+++ b/roles/runc/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Download runc
   get_url:
-    url: https://github.com/opencontainers/runc/releases/download/v1.0.0-rc93/runc.amd64
+    url: https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64
     dest: /usr/local/bin/runc
     mode: 0755
     owner: root
     group: root
-    checksum: sha256:9feaa82be15cb190cf0ed76fcb6d22841abd18088d275a47e894cd1e3a0ee4b6
+    checksum: sha256:db772be63147a4e747b4fe286c7c16a2edc4a8458bd3092ea46aaee77750e8ce


### PR DESCRIPTION
Also upgrades:
* containerd to `1.6.12`
* runc to `1.1.4`
* etcd to `3.5.6`
* CNI plugins to `0.9.1`

Known dangers:
* Data corruption issue was found in etcd v3.5.0 release that was shipped with 1.22 Kubernetes release. Please read up-to-date production recommendations for etcd. Affects etcd 3.5.0 to 3.5.2. We'll go straight to 3.5.4, so we should be fine.
* We cannot update CNI to the latest version, because flannel has been extracted to its own library: https://github.com/flannel-io/cni-plugin. Maybe we should extract both of them and make sure the binaries are in place?

TODO:
* [ ] Test properly